### PR TITLE
Feat/#3/room

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.modelmapper:modelmapper:3.1.1'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/edu/example/wayfarer/config/ModelMapperConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/ModelMapperConfig.java
@@ -1,0 +1,15 @@
+package edu.example.wayfarer.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        return modelMapper;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomListDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomListDTO.java
@@ -1,0 +1,27 @@
+package edu.example.wayfarer.dto.room;
+
+import edu.example.wayfarer.entity.Room;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoomListDTO {
+
+    private String title;
+    private String country;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    public RoomListDTO(Room room){
+        this.title = room.getTitle();
+        this.country = room.getCountry();
+        this.startDate = room.getStartDate();
+        this.endDate = room.getEndDate();
+    }
+
+}

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomRequestDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomRequestDTO.java
@@ -12,4 +12,5 @@ public class RoomRequestDTO {
     private String country;
     private LocalDate startDate;
     private LocalDate endDate;
+    private String hostEmail;   // 임시, 나중에 로그인해서 알아서 받아오게 하면 될 것 같아요
 }

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomRequestDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomRequestDTO.java
@@ -1,0 +1,15 @@
+package edu.example.wayfarer.dto.room;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class RoomRequestDTO {
+    private String title;
+    private String country;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomResponseDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomResponseDTO.java
@@ -1,11 +1,13 @@
 package edu.example.wayfarer.dto.room;
 
+import edu.example.wayfarer.entity.MemberRoom;
 import edu.example.wayfarer.entity.Room;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomResponseDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomResponseDTO.java
@@ -1,0 +1,37 @@
+package edu.example.wayfarer.dto.room;
+
+import edu.example.wayfarer.entity.Room;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class RoomResponseDTO {
+
+    private String roomId;
+    private String title;
+    private String country;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String roomCode;
+    private String hostEmail;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public RoomResponseDTO(Room room) {
+        this.roomId = room.getRoomId();
+        this.title = room.getTitle();
+        this.country = room.getCountry();
+        this.startDate = room.getStartDate();
+        this.endDate = room.getEndDate();
+        this.roomCode = room.getRoomCode();
+        this.hostEmail = room.getHostEmail();
+        this.createdAt = room.getCreatedAt();
+        this.updatedAt = room.getUpdatedAt();
+
+    }
+
+}

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomUpdateDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomUpdateDTO.java
@@ -1,0 +1,12 @@
+package edu.example.wayfarer.dto.room;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RoomUpdateDTO {
+    private Long roomId;
+    private String title;
+    private String country;
+}

--- a/src/main/java/edu/example/wayfarer/dto/room/RoomUpdateDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/room/RoomUpdateDTO.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class RoomUpdateDTO {
-    private Long roomId;
+    private String roomId;
     private String title;
     private String country;
 }

--- a/src/main/java/edu/example/wayfarer/entity/MemberRoom.java
+++ b/src/main/java/edu/example/wayfarer/entity/MemberRoom.java
@@ -1,10 +1,12 @@
 package edu.example.wayfarer.entity;
 
+import edu.example.wayfarer.entity.enums.Color;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -28,6 +30,8 @@ public class MemberRoom {
     @ManyToOne
     @JoinColumn(name = "email")
     private Member member;
-    private String color;
+    private Color color;
+
+    @CreatedDate
     private LocalDateTime joinDate;
 }

--- a/src/main/java/edu/example/wayfarer/entity/Room.java
+++ b/src/main/java/edu/example/wayfarer/entity/Room.java
@@ -4,10 +4,7 @@ package edu.example.wayfarer.entity;
 
 import edu.example.wayfarer.util.RandomStringGenerator;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +16,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 @Builder
 @EntityListeners(AuditingEntityListener.class)
 @Entity
@@ -48,7 +46,7 @@ public class Room {
     @PrePersist // when generating unique identifiers
     public void generateRoomId(){
         if(this.roomId == null || this.roomId.isBlank()){
-            this.roomId = RandomStringGenerator.generateRandomString(20);
+            this.roomId = RandomStringGenerator.generateRandomString(8);
         }
         if (this.roomCode == null || this.roomCode.isBlank()) {
             this.roomCode = RandomStringGenerator.generateRandomString(8);

--- a/src/main/java/edu/example/wayfarer/entity/Room.java
+++ b/src/main/java/edu/example/wayfarer/entity/Room.java
@@ -55,5 +55,13 @@ public class Room {
         }
     }
 
+    public void changeTitle(String title){
+        this.title = title;
+    }
+
+    public void changeCountry(String country){
+        this.country = country;
+    }
+
 
 }

--- a/src/main/java/edu/example/wayfarer/entity/Room.java
+++ b/src/main/java/edu/example/wayfarer/entity/Room.java
@@ -2,14 +2,14 @@ package edu.example.wayfarer.entity;
 
 
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import edu.example.wayfarer.util.RandomStringGenerator;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
@@ -32,13 +32,28 @@ public class Room {
     private LocalDate startDate;
     private LocalDate endDate;
     private String roomCode;
+
     private String hostEmail;
+
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "room")
     private List<MemberRoom> memberRooms;
 
+    // Room 생성시 랜덤 roomId 할당
+    @PrePersist // when generating unique identifiers
+    public void generateRoomId(){
+        if(this.roomId == null || this.roomId.isBlank()){
+            this.roomId = RandomStringGenerator.generateRandomString(20);
+        }
+        if (this.roomCode == null || this.roomCode.isBlank()) {
+            this.roomCode = RandomStringGenerator.generateRandomString(8);
+        }
+    }
 
 
 }

--- a/src/main/java/edu/example/wayfarer/entity/Room.java
+++ b/src/main/java/edu/example/wayfarer/entity/Room.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,8 +29,8 @@ public class Room {
 
     private String title;
     private String country;
-    private LocalDateTime startDate;
-    private LocalDateTime endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String roomCode;
     private String hostEmail;
     private LocalDateTime createdAt;

--- a/src/main/java/edu/example/wayfarer/entity/Schedule.java
+++ b/src/main/java/edu/example/wayfarer/entity/Schedule.java
@@ -25,6 +25,7 @@ public class Schedule {
     @JoinColumn(name = "room_id")
     private Room room;
 
+    @Enumerated(EnumType.STRING)
     private PlanType planType;
     private LocalDate date;
 

--- a/src/main/java/edu/example/wayfarer/entity/enums/Color.java
+++ b/src/main/java/edu/example/wayfarer/entity/enums/Color.java
@@ -1,0 +1,26 @@
+package edu.example.wayfarer.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Color {
+    RED("#F72216"),
+    ORANGE("#FF9500"),
+    YELLOW("#FFCC00"),
+    GREEN("#34c759"),
+    BABYBLUE("#00C7BE"),
+    BLUE("#007AFF"),
+    PURPLE("#AF52DE"),
+    HOTPINK("#FF2D55"),
+    BROWN("#A2845E"),
+    WHITE("#FFFFFF"),
+    GREY("#8E8E93");
+
+    private final String hexCode;
+
+    Color(String hexCode) {
+        this.hexCode = hexCode;
+    }
+
+
+}

--- a/src/main/java/edu/example/wayfarer/entity/enums/PlanType.java
+++ b/src/main/java/edu/example/wayfarer/entity/enums/PlanType.java
@@ -1,5 +1,5 @@
 package edu.example.wayfarer.entity.enums;
 
 public enum PlanType {
-    A, B
+    A, B, C
 }

--- a/src/main/java/edu/example/wayfarer/repository/MemberRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package edu.example.wayfarer.repository;
 import edu.example.wayfarer.entity.Member;
 import edu.example.wayfarer.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 }

--- a/src/main/java/edu/example/wayfarer/repository/MemberRoomRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/MemberRoomRepository.java
@@ -1,0 +1,7 @@
+package edu.example.wayfarer.repository;
+
+import edu.example.wayfarer.entity.MemberRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
+}

--- a/src/main/java/edu/example/wayfarer/repository/MemberRoomRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/MemberRoomRepository.java
@@ -2,6 +2,17 @@ package edu.example.wayfarer.repository;
 
 import edu.example.wayfarer.entity.MemberRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
+    @Query("select mb from MemberRoom mb where mb.room.roomId = :roomId")
+    public MemberRoom findByRoomId(@Param("roomId") String roomId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM MemberRoom mr WHERE mr.room.roomId = :roomId")
+    void deleteByRoomId(@Param("roomId") String roomId);
 }

--- a/src/main/java/edu/example/wayfarer/repository/ScheduleRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/ScheduleRepository.java
@@ -3,6 +3,16 @@ package edu.example.wayfarer.repository;
 import edu.example.wayfarer.entity.Room;
 import edu.example.wayfarer.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, String> {
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Schedule s WHERE s.room.roomId = :roomId")
+    void deleteByRoomId(@Param("roomId") String roomId);
+
 }

--- a/src/main/java/edu/example/wayfarer/service/RoomService.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomService.java
@@ -1,0 +1,17 @@
+package edu.example.wayfarer.service;
+
+import edu.example.wayfarer.dto.room.RoomListDTO;
+import edu.example.wayfarer.dto.room.RoomRequestDTO;
+import edu.example.wayfarer.dto.room.RoomResponseDTO;
+import edu.example.wayfarer.dto.room.RoomUpdateDTO;
+
+import java.util.List;
+
+public interface RoomService {
+
+    RoomResponseDTO create(RoomRequestDTO roomRequestDTO);
+    RoomResponseDTO read(String roomId);
+    RoomResponseDTO update(RoomUpdateDTO roomUpdateDTO);
+    void delete(String roomId);
+    List<RoomListDTO> getList();
+}

--- a/src/main/java/edu/example/wayfarer/service/RoomService.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomService.java
@@ -13,5 +13,5 @@ public interface RoomService {
     RoomResponseDTO read(String roomId);
     RoomResponseDTO update(RoomUpdateDTO roomUpdateDTO);
     void delete(String roomId);
-    List<RoomListDTO> getList();
+//    List<RoomListDTO> getList();
 }

--- a/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
@@ -14,7 +14,6 @@ import edu.example.wayfarer.repository.MemberRepository;
 import edu.example.wayfarer.repository.MemberRoomRepository;
 import edu.example.wayfarer.repository.RoomRepository;
 import edu.example.wayfarer.repository.ScheduleRepository;
-import edu.example.wayfarer.util.RandomStringGenerator;
 
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -120,11 +119,16 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     public void delete(String roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new NoSuchElementException("삭제할 방이 존재하지 않습니다."));
 
+        scheduleRepository.deleteByRoomId(roomId);
+        memberRoomRepository.deleteByRoomId(roomId);
+        roomRepository.delete(room);
     }
 
-    @Override
-    public List<RoomListDTO> getList() {
-        return List.of();
-    }
+//    @Override
+//    public List<RoomListDTO> getList() {
+//        return List.of();
+//    }
 }

--- a/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
@@ -1,0 +1,121 @@
+package edu.example.wayfarer.service;
+
+import edu.example.wayfarer.dto.room.RoomListDTO;
+import edu.example.wayfarer.dto.room.RoomRequestDTO;
+import edu.example.wayfarer.dto.room.RoomResponseDTO;
+import edu.example.wayfarer.dto.room.RoomUpdateDTO;
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.entity.MemberRoom;
+import edu.example.wayfarer.entity.Room;
+import edu.example.wayfarer.entity.Schedule;
+import edu.example.wayfarer.entity.enums.Color;
+import edu.example.wayfarer.entity.enums.PlanType;
+import edu.example.wayfarer.repository.MemberRepository;
+import edu.example.wayfarer.repository.MemberRoomRepository;
+import edu.example.wayfarer.repository.RoomRepository;
+import edu.example.wayfarer.repository.ScheduleRepository;
+import edu.example.wayfarer.util.RandomStringGenerator;
+
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoomServiceImpl implements RoomService {
+    private final RoomRepository roomRepository;
+    private final MemberRepository memberRepository;
+    private final MemberRoomRepository memberRoomRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Override
+    @Transactional
+    public RoomResponseDTO create(RoomRequestDTO roomRequestDTO) {
+        // 여행 끝 날짜가 더 나중이 맞는지 확인
+        if(roomRequestDTO.getStartDate().isAfter(roomRequestDTO.getEndDate())) {
+            throw new IllegalArgumentException("Start date cannot be after end date");
+        }
+
+        // room 저장
+        Room room = modelMapper.map(roomRequestDTO, Room.class);
+        System.out.println("Host email: " + room.getHostEmail());
+
+        // roomId 생성하고 중복 확인
+        String roomId;
+        do{
+            room.generateRoomId();
+            roomId = room.getRoomId();
+        }while (roomRepository.existsById(roomId));
+        Room savedRoom = roomRepository.save(room);
+        System.out.println("Saved Room ID: " + savedRoom.getRoomId());
+        System.out.println("Host email: " + room.getHostEmail());
+
+
+        //memberRoom 저장
+        // 방장을 찾는다
+        Member foundMember = memberRepository.findById(room.getHostEmail()).orElseThrow();
+        // Color enum을 배열화
+        Color[] colors = Color.values();
+        // memberRoom을 build
+        MemberRoom memberRoom = MemberRoom.builder()
+                .member(foundMember)
+                .room(savedRoom)
+                .color(colors[1]).build();
+        memberRoomRepository.save(memberRoom);
+
+        // schedule 저장
+        List<Schedule> schedules = new ArrayList<>();
+        LocalDate currentDate = roomRequestDTO.getStartDate();
+
+        while(!currentDate.isAfter(roomRequestDTO.getEndDate())) {
+            for(PlanType planType : PlanType.values()) {
+                schedules.add(Schedule.builder()
+                        .room(savedRoom)
+                        .planType(planType)
+                        .date(currentDate)
+                        .build()
+                );
+
+            }
+            currentDate = currentDate.plusDays(1);
+        }
+        for (Schedule schedule : schedules) {
+            System.out.println("Schedule: date=" + schedule.getDate() +
+                    ", planType=" + schedule.getPlanType() +
+                    ", roomId=" + (schedule.getRoom() != null ? schedule.getRoom().getRoomId() : "null"));
+
+            scheduleRepository.save(schedule);
+        }
+
+        return new RoomResponseDTO(savedRoom);
+    }
+
+    @Override
+    public RoomResponseDTO read(String roomId) {
+        return null;
+    }
+
+    @Override
+    public RoomResponseDTO update(RoomUpdateDTO roomUpdateDTO) {
+        return null;
+    }
+
+    @Override
+    public void delete(String roomId) {
+
+    }
+
+    @Override
+    public List<RoomListDTO> getList() {
+        return List.of();
+    }
+}

--- a/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -101,7 +102,9 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     public RoomResponseDTO read(String roomId) {
-        return null;
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(()-> new NoSuchElementException("해당 방이 존재하지 않습니다."));
+        return new RoomResponseDTO(room);
     }
 
     @Override

--- a/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
@@ -109,7 +109,13 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     public RoomResponseDTO update(RoomUpdateDTO roomUpdateDTO) {
-        return null;
+        Room room = roomRepository.findById(roomUpdateDTO.getRoomId())
+                .orElseThrow(()-> new NoSuchElementException("해당 방이 존재하지 않습니다."));
+
+        room.changeCountry(roomUpdateDTO.getCountry());
+        room.changeTitle(roomUpdateDTO.getTitle());
+
+        return new RoomResponseDTO(roomRepository.save(room));
     }
 
     @Override

--- a/src/main/java/edu/example/wayfarer/util/RandomStringGenerator.java
+++ b/src/main/java/edu/example/wayfarer/util/RandomStringGenerator.java
@@ -1,0 +1,16 @@
+package edu.example.wayfarer.util;
+
+import java.security.SecureRandom;
+
+public class RandomStringGenerator {
+    private static final String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final SecureRandom random = new SecureRandom();
+
+    public static String generateRandomString(int length){
+        StringBuilder result = new StringBuilder(length);
+        for(int i = 0; i < length; i++){
+            result.append(characters.charAt(random.nextInt(characters.length())));
+        }
+        return result.toString();
+    }
+}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,8 @@
+# H2 ?????? ?? ??
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:test
+spring.datasource.username=
+spring.datasource.password=
+
+# H2 ??????? ?? ??
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/test/java/edu/example/wayfarer/repository/RoomRepostioryTest.java
+++ b/src/test/java/edu/example/wayfarer/repository/RoomRepostioryTest.java
@@ -5,40 +5,41 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Commit;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 //@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 //@TestPropertySource(locations = "classpath:application-test.properties")
-@Transactional
 public class RoomRepostioryTest {
 
     @Autowired
     private RoomRepository roomRepository;
 
-    @BeforeEach
-    void setup(){
-        roomRepository.deleteAll(); // 기존 방 삭제
-
-    }
+//    @BeforeEach
+//    void setup(){
+//        roomRepository.deleteAll(); // 기존 방 삭제
+//
+//    }
 
     @Test
     @DisplayName("방 생성 테스트")
     @Commit
-    void testCreateRoom(){
+    @Transactional
+    public void testCreateRoom(){
 
         Room room = Room.builder()
-                .country("Japan")
-                .hostEmail("example@a.com")
-                .startDate(LocalDate.of(2024, 12, 1))
-                .endDate(LocalDate.of(2024, 12, 4))
-                .title("공주들")
+                .country("HongKong")
+                .hostEmail("zz@a.com")
+                .startDate(LocalDate.of(2025, 1, 6))
+                .endDate(LocalDate.of(2025, 1, 10))
+                .title("에타기다려")
                 .build();
 
         Room savedRoom = roomRepository.save(room);
@@ -47,7 +48,52 @@ public class RoomRepostioryTest {
 
     }
 
+    @Test
+    public void testReadRoom(){
+        String roomId = "NZQxJBkIToYgEKVTnrO6";
 
+        Room room = roomRepository.findById(roomId).orElse(null);
 
+        assertNotNull(room);
+        assertThat(room.getRoomId()).isEqualTo(roomId);
+        System.out.println(room.getRoomCode() + " " + room.getTitle());
+    }
+
+    @Test
+    @Transactional
+    @Commit
+    public void testUpdateRoom(){
+        String roomId = "NZQxJBkIToYgEKVTnrO6";
+        String country = "USA";
+        String title = "미국기행";
+
+        Optional<Room> foundRoom = roomRepository.findById(roomId);
+        assertTrue(foundRoom.isPresent());
+        Room room = foundRoom.get();
+
+        room.changeCountry(country);
+        room.changeTitle(title);
+
+        assertEquals(country, room.getCountry());
+        assertEquals(title, room.getTitle());
+    }
+
+    @Test
+    @Transactional
+    @Commit
+    public void testDeleteRoom(){
+        String roomId = "NZQxJBkIToYgEKVTnrO6";
+        assertTrue(roomRepository.findById(roomId).isPresent());
+
+        roomRepository.deleteById(roomId);
+        assertFalse(roomRepository.findById(roomId).isPresent());
+    }
+
+    @Test
+    public void testReadAllRoom(){
+        List<Room> rooms = roomRepository.findAll();
+        assertNotNull(rooms);
+        System.out.println("rooms : " + rooms.get(0).getTitle() + " " + rooms.get(1).getTitle());
+    }
 
 }

--- a/src/test/java/edu/example/wayfarer/repository/RoomRepostioryTest.java
+++ b/src/test/java/edu/example/wayfarer/repository/RoomRepostioryTest.java
@@ -1,0 +1,53 @@
+package edu.example.wayfarer.repository;
+
+import edu.example.wayfarer.entity.Room;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+//@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+//@TestPropertySource(locations = "classpath:application-test.properties")
+@Transactional
+public class RoomRepostioryTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @BeforeEach
+    void setup(){
+        roomRepository.deleteAll(); // 기존 방 삭제
+
+    }
+
+    @Test
+    @DisplayName("방 생성 테스트")
+    @Commit
+    void testCreateRoom(){
+
+        Room room = Room.builder()
+                .country("Japan")
+                .hostEmail("example@a.com")
+                .startDate(LocalDate.of(2024, 12, 1))
+                .endDate(LocalDate.of(2024, 12, 4))
+                .title("공주들")
+                .build();
+
+        Room savedRoom = roomRepository.save(room);
+        assertNotNull(room.getRoomId());
+        assertThat(savedRoom).isNotNull();
+
+    }
+
+
+
+
+}

--- a/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
+++ b/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
@@ -28,10 +28,10 @@ public class RoomServiceTest {
     @Commit
     public void testCreateRoom() {
         RoomRequestDTO roomRequestDTO = new RoomRequestDTO();
-        roomRequestDTO.setTitle("여행!!!!");
-        roomRequestDTO.setCountry("마카오");
-        roomRequestDTO.setStartDate(LocalDate.of(2025,1,6));
-        roomRequestDTO.setEndDate(LocalDate.of(2025,1,10));
+        roomRequestDTO.setTitle("크리스마스 흐흐");
+        roomRequestDTO.setCountry("서울");
+        roomRequestDTO.setStartDate(LocalDate.of(2024,12,24));
+        roomRequestDTO.setEndDate(LocalDate.of(2024,12,25));
         roomRequestDTO.setHostEmail("aa@aa.com");
 
         RoomResponseDTO result = roomService.create(roomRequestDTO);
@@ -61,6 +61,13 @@ public class RoomServiceTest {
         assertNotNull(result);
         assertEquals("중국", result.getCountry());
         assertEquals("후후탕후루를먹자", result.getTitle());
+    }
 
+    @Test
+    @Transactional
+    @Commit
+    public void testDeleteRoom(){
+        String roomId = "vTJBdpwg";
+        roomService.delete(roomId);
     }
 }

--- a/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
+++ b/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
@@ -1,0 +1,40 @@
+package edu.example.wayfarer.service;
+
+import edu.example.wayfarer.dto.room.RoomRequestDTO;
+import edu.example.wayfarer.dto.room.RoomResponseDTO;
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class RoomServiceTest {
+    @Autowired
+    private RoomService roomService;
+
+    @Test
+    @Transactional
+    @Commit
+    public void testCreateRoom() {
+        RoomRequestDTO roomRequestDTO = new RoomRequestDTO();
+        roomRequestDTO.setTitle("여행!!!!");
+        roomRequestDTO.setCountry("마카오");
+        roomRequestDTO.setStartDate(LocalDate.of(2025,1,6));
+        roomRequestDTO.setEndDate(LocalDate.of(2025,1,10));
+        roomRequestDTO.setHostEmail("aa@aa.com");
+
+        RoomResponseDTO result = roomService.create(roomRequestDTO);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
+++ b/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
@@ -2,8 +2,7 @@ package edu.example.wayfarer.service;
 
 import edu.example.wayfarer.dto.room.RoomRequestDTO;
 import edu.example.wayfarer.dto.room.RoomResponseDTO;
-import edu.example.wayfarer.entity.Member;
-import edu.example.wayfarer.repository.MemberRepository;
+import edu.example.wayfarer.dto.room.RoomUpdateDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -14,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
@@ -45,5 +45,22 @@ public class RoomServiceTest {
         RoomResponseDTO result = roomService.read(roomId);
         assertNotNull(result);
         System.out.println(result);
+    }
+
+    @Test
+    @Transactional
+    @Commit
+    public void testUpdateRoom() {
+        String roomId = "xu688Ljt";
+        RoomUpdateDTO roomUpdateDTO = new RoomUpdateDTO();
+        roomUpdateDTO.setRoomId(roomId);
+        roomUpdateDTO.setCountry("중국");
+        roomUpdateDTO.setTitle("후후탕후루를먹자");
+
+        RoomResponseDTO result = roomService.update(roomUpdateDTO);
+        assertNotNull(result);
+        assertEquals("중국", result.getCountry());
+        assertEquals("후후탕후루를먹자", result.getTitle());
+
     }
 }

--- a/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
+++ b/src/test/java/edu/example/wayfarer/service/RoomServiceTest.java
@@ -37,4 +37,13 @@ public class RoomServiceTest {
         RoomResponseDTO result = roomService.create(roomRequestDTO);
         assertNotNull(result);
     }
+
+    @Test
+    public void testReadRoom(){
+        String roomId = "xu688Ljt";
+
+        RoomResponseDTO result = roomService.read(roomId);
+        assertNotNull(result);
+        System.out.println(result);
+    }
 }


### PR DESCRIPTION
Room 기본 CRUD 기능 완료했습니다.
 
## Room create시
 이에 해당하는 roomMember, schedule 도 생성되도록 설정해뒀습니다. 그런데 코드가 좀 길어져서 리팩토링이 좀 필요해 보입니다.

## Room delete시
해당 roomId가 포함되어있는 모든 roomMember, schedule 데이터 삭제되도록 했습니다.

## 특이사항
- 방장 위임 기능은 확정이 아니라고 하셔서 일단 수정할 수 없게 해뒀습니다.
- 현재 워크벤치의 설정상으로는 schedule에 알 수 없는 수상한 schedule_chk_1이라는 제약조건이 있는데 이게 있으면 create가 동작하지 않습니다. "ALTER TABLE schedule DROP CHECK schedule_chk_1;" 하셔서 제약조건 없애신 후 실행하시면 됩니다.
- 특정 색들이 정해져 있어서 String color 대신 Color Enum을 만들어 11개의 색 모두 넣어뒀습니다. (확정마크 색 + 나머지)
- 모델매퍼 사용하기로 했기에 관련 config 추가했습니다.
- util 디렉토리 밑에 RandomStringGenerator는 roodId와 roomCode를 위한 랜덤문자열생성 메서드 입니다.
- 테스트 시 랜덤 문자열이 만들어져야 이를 가지고 나머지도 테스트할 수 있어서 한번에 테스트 돌리는 것 못했습니다. 대신 각 기능 하나씩 돌아가는 것은 모두 여러번 확인 했습니다.
- RoomRequestDTO에 hostEmail필드를 추가되었는데, 이는 임시입니다. 로그인 기능이 추가되면 없애고 알아서 들어가게 할 예정입니다.
