### PR TITLE
소셜 로그인 PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,16 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'com.google.code.gson:gson'
+
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Swagger Setting
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/edu/example/wayfarer/apiPayload/BaseResponse.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/BaseResponse.java
@@ -1,0 +1,39 @@
+package edu.example.wayfarer.apiPayload;
+
+import edu.example.wayfarer.apiPayload.code.BaseCode;
+import edu.example.wayfarer.apiPayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class BaseResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+
+    public static <T> BaseResponse<T> onSuccess(T result) {
+        return new BaseResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> BaseResponse<T> of(BaseCode code, T result) {
+        return new BaseResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> BaseResponse<T> onFailure(String code, String message, T data) {
+        return new BaseResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/BaseCode.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package edu.example.wayfarer.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package edu.example.wayfarer.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,14 @@
+package edu.example.wayfarer.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+    private final boolean isSuccess;
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,15 @@
+package edu.example.wayfarer.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,59 @@
+package edu.example.wayfarer.apiPayload.code.status;
+
+import edu.example.wayfarer.apiPayload.code.BaseErrorCode;
+import edu.example.wayfarer.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 기본 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // user 에러
+    _NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MEMBER400", "member를 찾을 수 없습니다."),
+
+    // post 에러
+    _NOT_FOUND_POST(HttpStatus.NOT_FOUND, "POST400", "post를 찾을 수 없습니다."),
+
+    // reply 에러
+    _NOT_FOUND_REPLY(HttpStatus.NOT_FOUND, "REPLY400", "reply를 찾을 수 없습니다."),
+
+    // token 에러
+    _AUTH_EXPIRE_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN401_0", "토큰이 만료되었습니다."),
+    _AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN401_1", "토큰이 부적절합니다."),
+    _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "TOKEN404_0", "토큰이 존재하지 않습니다."),
+    _INVALID_PROVIDER(HttpStatus.UNAUTHORIZED,"PROVIDER400","비인가된 Provider입니다."),
+    // 인증관련
+    _AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH401_0", "인증에 실패했습니다."),
+    _BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH401_1", "비밀번호를 잘못 입력했습니다."),
+    _ACCOUNT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_4", "아이디를 잘못 입력했습니다. 회원가입 후 이용해주세요."),
+
+    // 파싱 에러
+    _PARSING_ERROR(HttpStatus.BAD_REQUEST, "PARSE400", "데이터 파싱 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder().message(message).code(code).isSuccess(false).build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,35 @@
+package edu.example.wayfarer.apiPayload.code.status;
+
+
+import edu.example.wayfarer.apiPayload.code.BaseCode;
+import edu.example.wayfarer.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "COMMON201", "요청 성공 및 리소스 생성됨");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder().message(message).code(code).isSuccess(true).build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,131 @@
+package edu.example.wayfarer.apiPayload.exception;
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import edu.example.wayfarer.apiPayload.code.ErrorReasonDTO;
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(
+                        fieldError -> {
+                            String fieldName = fieldError.getField();
+                            String errorMessage =
+                                    Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            errors.merge(
+                                    fieldName,
+                                    errorMessage,
+                                    (existingErrorMessage, newErrorMessage) ->
+                                            existingErrorMessage + ", " + newErrorMessage);
+                        });
+
+        return handleExceptionInternalArgs(
+                e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        BaseResponse<Object> body = BaseResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        BaseResponse<Object> body = BaseResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/exception/GeneralException.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package edu.example.wayfarer.apiPayload.exception;
+
+import edu.example.wayfarer.apiPayload.code.BaseErrorCode;
+import edu.example.wayfarer.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}
+

--- a/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/AuthHandler.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/AuthHandler.java
@@ -1,0 +1,11 @@
+package edu.example.wayfarer.apiPayload.exception.handler;
+
+import edu.example.wayfarer.apiPayload.code.BaseErrorCode;
+import edu.example.wayfarer.apiPayload.exception.GeneralException;
+
+public class AuthHandler extends GeneralException {
+
+    public AuthHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package edu.example.wayfarer.apiPayload.exception.handler;
+
+import edu.example.wayfarer.apiPayload.code.BaseErrorCode;
+import edu.example.wayfarer.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/TestHandler.java
+++ b/src/main/java/edu/example/wayfarer/apiPayload/exception/handler/TestHandler.java
@@ -1,0 +1,10 @@
+package edu.example.wayfarer.apiPayload.exception.handler;
+
+import edu.example.wayfarer.apiPayload.code.BaseErrorCode;
+import edu.example.wayfarer.apiPayload.exception.GeneralException;
+
+public class TestHandler extends GeneralException {
+    public TestHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/constant/SecurityConstants.java
+++ b/src/main/java/edu/example/wayfarer/auth/constant/SecurityConstants.java
@@ -1,0 +1,27 @@
+package edu.example.wayfarer.auth.constant;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class SecurityConstants {
+
+    public static final String[] swaggerUrls = {"/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**"};
+    public static final String[] allowUrls = {
+            "/api/v1/posts/**",
+            "/api/v1/replies/**",
+            "/login",
+            "/auth/kakao/callback/**",
+            "/auth/login/google", // 구글 경로 추가
+            "/login/oauth2/code/google", // OAuth 리다이렉트 경로 추가
+            "/logout",
+            "/refresh",
+            "/favicon.ico",
+            "/", // 메인페이지
+            "/auth/logout"
+     };
+
+    // 허용 Urls
+    public static String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(allowUrls))
+            .toArray(String[]::new);
+
+}

--- a/src/main/java/edu/example/wayfarer/auth/filter/CustomDaoAuthenticationProvider.java
+++ b/src/main/java/edu/example/wayfarer/auth/filter/CustomDaoAuthenticationProvider.java
@@ -1,0 +1,11 @@
+package edu.example.wayfarer.auth.filter;
+
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+
+public class CustomDaoAuthenticationProvider extends DaoAuthenticationProvider {
+
+    public CustomDaoAuthenticationProvider() {
+        // hideUserNotFoundExceptions 값을 false로 설정
+        this.setHideUserNotFoundExceptions(false);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/edu/example/wayfarer/auth/filter/JwtAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package edu.example.wayfarer.auth.filter;
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(403);
+
+        BaseResponse<Object> errorResponse =
+                BaseResponse.onFailure(
+                        ErrorStatus._FORBIDDEN.getCode(),
+                        ErrorStatus._FORBIDDEN.getMessage(),
+                        null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/edu/example/wayfarer/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,37 @@
+package edu.example.wayfarer.auth.filter;
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AuthHandler e) {
+            response.setContentType("application/json; charset=UTF-8");
+            response.setStatus(e.getErrorReasonHttpStatus().getHttpStatus().value());
+
+            ErrorStatus code = (ErrorStatus) e.getCode();
+
+            BaseResponse<Object> errorResponse =
+                    BaseResponse.onFailure(code.getCode(), code.getMessage(), null);
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.writeValue(response.getOutputStream(), errorResponse);
+        }
+
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/filter/JwtFilter.java
+++ b/src/main/java/edu/example/wayfarer/auth/filter/JwtFilter.java
@@ -1,0 +1,67 @@
+package edu.example.wayfarer.auth.filter;
+
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.auth.constant.SecurityConstants;
+import edu.example.wayfarer.auth.userdetails.PrincipalDetailsService;
+import edu.example.wayfarer.auth.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final PrincipalDetailsService principalDetailsService;
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        boolean shouldSkip = path.startsWith("/login/oauth2/code/google") ||
+                path.startsWith("/auth/google/callback") ||
+                Arrays.stream(SecurityConstants.allowedUrls)
+                        .anyMatch(pattern -> antPathMatcher.match(pattern, path));
+
+        log.info("Should skip JwtFilter for path {}: {}", path, shouldSkip); // 추가된 로그
+        return shouldSkip;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = jwtUtil.resolveAccessToken(request);
+
+        if(jwtUtil.isAccessTokenValid(accessToken)) {
+            String email = jwtUtil.getEmail(accessToken);
+            UserDetails userDetails = principalDetailsService.loadUserByUsername(email);
+
+            if (userDetails != null) {
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails, "", userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            } else {
+                throw new AuthHandler(ErrorStatus._NOT_FOUND_MEMBER);
+            }
+        } else {
+            throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/filter/LoginFilter.java
+++ b/src/main/java/edu/example/wayfarer/auth/filter/LoginFilter.java
@@ -1,0 +1,108 @@
+package edu.example.wayfarer.auth.filter;
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.auth.userdetails.PrincipalDetails;
+import edu.example.wayfarer.auth.util.JwtUtil;
+import edu.example.wayfarer.dto.member.MemberRequestDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+// 스프링 시큐리티에 UsernamePasswordAuthenticationFilter 라는게 있음
+// /login 요청해서 username,password 전송하면 (POST)
+// UsernamePasswordAuthenticationFilter 필터가 작동함
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    // /login 요청을 하면, 로그인 시도를 위해서 실행되는 함수
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        MemberRequestDTO.LoginRequestDTO loginRequestDto = readBody(request);
+
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                UsernamePasswordAuthenticationToken.unauthenticated(loginRequestDto.getEmail(), loginRequestDto.getPassword());
+
+        return authenticationManager.authenticate(usernamePasswordAuthenticationToken);
+    }
+
+    private MemberRequestDTO.LoginRequestDTO readBody(HttpServletRequest request) {
+        MemberRequestDTO.LoginRequestDTO loginRequestDto = null;
+        ObjectMapper om = new ObjectMapper();
+
+        try {
+            loginRequestDto = om.readValue(request.getInputStream(), MemberRequestDTO.LoginRequestDTO.class);
+        } catch (IOException e) {
+            throw new AuthHandler(ErrorStatus._BAD_REQUEST);
+        }
+
+        return loginRequestDto;
+    }
+
+
+    // JWT Token 생성해서 response에 담아주기
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+                                            Authentication authResult) throws IOException{
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
+
+        String email = principalDetails.getUsername();
+        Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createAccessToken(email, role);
+
+        response.addHeader("Authorization", "Bearer " + token);
+
+        // 성공 응답 통일
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpStatus.OK.value());
+
+        BaseResponse<Object> errorResponse =
+                BaseResponse.onSuccess(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+        System.out.println("jwt token : " + token);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        ErrorStatus errorStatus;
+
+        if (failed instanceof UsernameNotFoundException) {
+            errorStatus = ErrorStatus._ACCOUNT_NOT_FOUND;
+        } else if (failed instanceof BadCredentialsException) {
+            errorStatus = ErrorStatus._BAD_CREDENTIALS;
+        } else {
+            errorStatus = ErrorStatus._AUTHENTICATION_FAILED;
+        }
+        throw new AuthHandler(errorStatus);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/userdetails/PrincipalDetails.java
+++ b/src/main/java/edu/example/wayfarer/auth/userdetails/PrincipalDetails.java
@@ -1,0 +1,55 @@
+package edu.example.wayfarer.auth.userdetails;
+
+import edu.example.wayfarer.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add(member.getRole());
+        return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/userdetails/PrincipalDetailsService.java
+++ b/src/main/java/edu/example/wayfarer/auth/userdetails/PrincipalDetailsService.java
@@ -1,0 +1,25 @@
+package edu.example.wayfarer.auth.userdetails;
+
+
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // 우리 프로젝트에서는 username이 email과 동치라서 아래와 같이 내비뒀습니다.
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("올바르지 않은 email"));
+        return new PrincipalDetails(member);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/util/GoogleUtil.java
+++ b/src/main/java/edu/example/wayfarer/auth/util/GoogleUtil.java
@@ -1,0 +1,86 @@
+package edu.example.wayfarer.auth.util;
+
+import edu.example.wayfarer.dto.GoogleUserInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class GoogleUtil {
+    @Value("${GOOGLE_CLIENT_ID}")
+    private String client_id;
+    @Value("${GOOGLE_CLIENT_SECRET}")
+    private String client_secret;
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirect_uri;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String getAccessToken(String authorizationCode) {
+        log.info("Authorization Code: {}", authorizationCode); // Authorization Code 로깅
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        body.add("client_id", client_id);
+        body.add("client_secret", client_secret);
+        body.add("redirect_uri", redirect_uri);
+        body.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        log.info("Access Token Request: {}", request); // 요청 로깅
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "https://oauth2.googleapis.com/token", request, Map.class);
+
+        log.info("Access Token Response: {}", response.getBody()); // 응답 로깅
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    public GoogleUserInfo getUserInfo(String accessToken) {
+        // Access Token으로 사용자 정보 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<GoogleUserInfo> response = restTemplate.exchange(
+                "https://openidconnect.googleapis.com/v1/userinfo",
+                HttpMethod.GET, request, GoogleUserInfo.class);
+
+        GoogleUserInfo userInfo = response.getBody();
+        userInfo.setGoogleAccessToken(accessToken); // Google Access Token 설정
+        return userInfo;
+    }
+
+    // 구글 Access Token을 폐기하는 메서드 추가
+    public void revokeToken(String token) {
+        String revokeUrl = "https://oauth2.googleapis.com/revoke?token=" + token;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(revokeUrl, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                log.info("Successfully revoked token: {}", token);
+            } else {
+                log.warn("Failed to revoke token: {}. Status Code: {}", token, response.getStatusCode());
+            }
+        } catch (Exception e) {
+            log.error("Error revoking token: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/util/HttpResponseUtil.java
+++ b/src/main/java/edu/example/wayfarer/auth/util/HttpResponseUtil.java
@@ -1,0 +1,34 @@
+package edu.example.wayfarer.auth.util;
+
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HttpResponseUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static void setSuccessResponse(HttpServletResponse response, HttpStatus httpStatus, Object body)
+            throws IOException {
+        String responseBody = objectMapper.writeValueAsString(BaseResponse.onSuccess(body));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(httpStatus.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+
+    public static void setErrorResponse(HttpServletResponse response, HttpStatus httpStatus, Object body)
+            throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(httpStatus.value());
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/util/JwtUtil.java
+++ b/src/main/java/edu/example/wayfarer/auth/util/JwtUtil.java
@@ -1,0 +1,125 @@
+package edu.example.wayfarer.auth.util;
+
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Component
+@Slf4j
+@Getter
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long accessTokenValiditySeconds;
+    private final long refreshTokenValiditySeconds;
+
+    public JwtUtil(
+            @Value("${spring.jwt.secret}") final String secretKey,
+            @Value("${spring.jwt.access-token-time}") final long accessTokenValiditySeconds,
+            @Value("${spring.jwt.refresh-token-time}") final long refreshTokenValiditySeconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValiditySeconds = accessTokenValiditySeconds;
+        this.refreshTokenValiditySeconds = refreshTokenValiditySeconds;
+    }
+
+    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰을 검색
+    public String resolveAccessToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null) {
+            log.warn("[*] Authorization header is null");
+        } else if (!authorization.startsWith("Bearer ")) {
+            log.warn("[*] Authorization header does not start with Bearer");
+        }
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.warn("[*] No Token in req");
+            throw new AuthHandler(ErrorStatus._TOKEN_NOT_FOUND);
+        }
+        log.info("[*] Token exists");
+        return authorization.split(" ")[1];
+    }
+
+    // Access Token 생성
+    public String createAccessToken(String email, String role) {
+        return createToken(email, role, accessTokenValiditySeconds);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(String email) {
+        return createToken(email, null, refreshTokenValiditySeconds);
+    }
+
+    private String createToken(String email, String role, long validitySeconds) {
+        Claims claims = Jwts.claims();
+        claims.put("email", email);
+        if (role != null) {
+            claims.put("role", role);
+        }
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(validitySeconds);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // Access Token에서 이메일 추출
+    public String getEmail(String token) {
+        return getClaims(token).getBody().get("email", String.class);
+    }
+
+    // Refresh Token에서 이메일 추출
+    public String getEmailFromRefreshToken(String token) {
+        return getClaims(token).getBody().get("email", String.class);
+    }
+
+    // Access Token 유효성 검증
+    public boolean isAccessTokenValid(String token) {
+        return validateToken(token);
+    }
+
+    // Refresh Token 유효성 검증
+    public boolean isRefreshTokenValid(String token) {
+        return validateToken(token);
+    }
+
+    // 토큰 검증 메서드
+    private boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = getClaims(token);
+            Date expiredDate = claims.getBody().getExpiration();
+            Date now = new Date();
+            return expiredDate.after(now);
+        } catch (ExpiredJwtException e) {
+            log.info("[*] _AUTH_EXPIRE_TOKEN");
+            throw new AuthHandler(ErrorStatus._AUTH_EXPIRE_TOKEN);
+        } catch (SignatureException
+                 | SecurityException
+                 | IllegalArgumentException
+                 | MalformedJwtException
+                 | UnsupportedJwtException e) {
+            log.info("[*] _AUTH_INVALID_TOKEN");
+            throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+        }
+    }
+
+    private Jws<Claims> getClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/auth/util/KakaoUtil.java
+++ b/src/main/java/edu/example/wayfarer/auth/util/KakaoUtil.java
@@ -1,0 +1,134 @@
+package edu.example.wayfarer.auth.util;
+
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.dto.KakaoDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+@Component
+@Slf4j
+public class KakaoUtil {
+
+    @Value("${spring.kakao.auth.client}")
+    private String client;
+    @Value("${spring.kakao.auth.redirect}")
+    private String redirect;
+    @Value("${kakao.api.url.mock:false}")
+    private boolean isMock;
+
+    public KakaoDTO.OAuthToken requestToken(String accessCode) {
+        if (isMock) {
+            KakaoDTO.OAuthToken token = new KakaoDTO.OAuthToken();
+            token.setAccess_token("mockAccessToken");
+            token.setRefresh_token("mockRefreshToken");
+            return token;
+        }
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_url", redirect);
+        params.add("code", accessCode);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange("https://kauth.kakao.com/oauth/token", HttpMethod.POST, kakaoTokenRequest, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        KakaoDTO.OAuthToken oAuthToken = null;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), KakaoDTO.OAuthToken.class);
+            log.info("oAuthToken : " + oAuthToken.getAccess_token());
+        } catch (JsonProcessingException e) {
+            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+        }
+        return oAuthToken;
+    }
+
+    public KakaoDTO.KakaoProfile requestProfile(KakaoDTO.OAuthToken oAuthToken){
+        RestTemplate restTemplate2 = new RestTemplate();
+        HttpHeaders headers2 = new HttpHeaders();
+
+        headers2.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers2.add("Authorization","Bearer "+ oAuthToken.getAccess_token());
+
+        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity <>(headers2);
+
+        ResponseEntity<String> response2 = restTemplate2.exchange(
+                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, kakaoProfileRequest, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        KakaoDTO.KakaoProfile kakaoProfile = null;
+
+        try {
+            System.out.println(response2.getBody());
+            kakaoProfile = objectMapper.readValue(response2.getBody(), KakaoDTO.KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            log.info(Arrays.toString(e.getStackTrace()));
+            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+        }
+
+        return kakaoProfile;
+    }
+
+    // 추가된 메서드: Kakao 토큰 폐기
+    public void revokeToken(String accessToken) {
+        if (isMock) {
+            log.info("Mock revoke token: " + accessToken);
+            return;
+        }
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        // 필요한 경우 추가 파라미터 설정
+
+        HttpEntity<MultiValueMap<String, String>> kakaoRevokeRequest = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v1/user/logout",
+                    HttpMethod.POST,
+                    kakaoRevokeRequest,
+                    String.class
+            );
+            log.info("Kakao token revoked: " + response.getBody());
+        } catch (Exception e) {
+            log.error("Error revoking Kakao token: " + e.getMessage());
+            throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+        }
+    }
+
+    // 추가된 메서드: Access Token으로부터 이메일 추출
+    public String getEmailFromAccessToken(String accessToken) {
+        KakaoDTO.KakaoProfile profile = requestProfile(new KakaoDTO.OAuthToken() {{
+            setAccess_token(accessToken);
+        }});
+        if (profile != null && profile.getKakao_account() != null && profile.getKakao_account().getEmail() != null) {
+            return profile.getKakao_account().getEmail();
+        }
+        return null;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/config/CorsConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/CorsConfig.java
@@ -1,0 +1,42 @@
+package edu.example.wayfarer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Bean
+    public static CorsConfigurationSource apiConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 응답 허용할 ip
+        List<String> allowedOriginPatterns = Arrays.asList("http://localhost:8080");//setAllowCredentials(true)와 함께 사용할 경우 특정 Origin을 명시적으로 지정해야 합니다
+        configuration.setAllowedOriginPatterns(allowedOriginPatterns);
+
+        // 응답 허용할 HTTP Method
+        List<String> allowedHttpMethods = Arrays.asList("GET", "POST", "PUT", "DELETE");
+        configuration.setAllowedMethods(allowedHttpMethods);
+
+        // 응답 허용할 header
+        List<String> allowedHeaders = Arrays.asList("*");
+        configuration.setAllowedHeaders(allowedHeaders);
+
+        // 내 서버가 응답을 할 때 응답해준 json을 자바스크립트에서 처리할 수 있게 할지를 설정
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        // /api/** 로 들어오는 모든 요청들은 config를 따르도록 등록!
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}

--- a/src/main/java/edu/example/wayfarer/config/RestTemplateConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/RestTemplateConfig.java
@@ -1,0 +1,25 @@
+package edu.example.wayfarer.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        messageConverters.add(new FormHttpMessageConverter());
+        restTemplate.setMessageConverters(messageConverters);
+
+        return restTemplate;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/config/SecurityConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/SecurityConfig.java
@@ -1,32 +1,98 @@
 package edu.example.wayfarer.config;
 
+import edu.example.wayfarer.auth.constant.SecurityConstants;
+import edu.example.wayfarer.auth.filter.*;
+import edu.example.wayfarer.auth.userdetails.PrincipalDetailsService;
+import edu.example.wayfarer.auth.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-
-//임시 config 파일입니다.
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
+    private final PrincipalDetailsService principalDetailsService;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    // PasswordEncoerder Been 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CustomDaoAuthenticationProvider customDaoAuthenticationProvider() {
+        CustomDaoAuthenticationProvider provider = new CustomDaoAuthenticationProvider();
+        provider.setUserDetailsService(principalDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf((auth) -> auth.disable()); // CSRF 비활성화
-        http.formLogin((auth) -> auth.disable()); // Form Login 비활성화
-        http.httpBasic((auth) -> auth.disable()); // HTTP Basic 비활성화
-        http
-                .authorizeRequests()
-                .requestMatchers("/**").permitAll();
+
+        // cors disable
+        http.cors(cors -> cors
+                .configurationSource(CorsConfig.apiConfigurationSource()));
+
+        // csrf disable
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // form 로그인 방식 disable
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // http basic 인증 방식 disable
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        // Session Stateless하게 관리
+        http.sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        // 경로별 인가
+        http.authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                .requestMatchers(HttpMethod.POST, "/api/v1/members").permitAll()
+                .requestMatchers(SecurityConstants.allowedUrls).permitAll()
+                .requestMatchers("/auth/google/**").permitAll() // 구글 소셜 로그인 경로 추가
+                .requestMatchers("/login/oauth2/code/google").permitAll() // OAuth 리다이렉트 경로 허용
+                .anyRequest().authenticated()
+        );
+
+        http.exceptionHandling(
+                (configurer ->
+                        configurer
+                                .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+        );
+
+        // JwtFilter를 UsernamePasswordAuthenticationFilter 이전에 추가
+        http.addFilterBefore(new JwtFilter(jwtUtil, principalDetailsService),
+                UsernamePasswordAuthenticationFilter.class);
+
+        // JwtExceptionFilter를 JwtFilter 이후에 추가
+        http.addFilterAfter(new JwtExceptionFilter(), JwtFilter.class);
+
+        // LoginFilter를 UsernamePasswordAuthenticationFilter 위치에 추가
+        http.addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil),
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/edu/example/wayfarer/controller/AuthController.java
+++ b/src/main/java/edu/example/wayfarer/controller/AuthController.java
@@ -1,0 +1,158 @@
+package edu.example.wayfarer.controller;
+
+import edu.example.wayfarer.apiPayload.BaseResponse;
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.converter.MemberConverter;
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.dto.GoogleUserInfo;
+import edu.example.wayfarer.dto.member.MemberResponseDTO;
+import edu.example.wayfarer.service.AuthService;
+import edu.example.wayfarer.auth.util.GoogleUtil;
+import edu.example.wayfarer.auth.util.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+    private final GoogleUtil googleUtil;
+
+    // Google 로그인 리다이렉트 엔드포인트
+    @GetMapping("/login/google")
+    public void redirectToGoogle(HttpServletResponse response,
+                                 @Value("${GOOGLE_CLIENT_ID}") String clientId,
+                                 @Value("${spring.security.oauth2.client.registration.google.redirect-uri}") String redirectUri) throws IOException {
+        String googleLoginUrl = "https://accounts.google.com/o/oauth2/auth?"
+                + "client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
+                + "&response_type=code"
+                + "&scope=" + URLEncoder.encode("email profile openid", StandardCharsets.UTF_8)
+                + "&prompt=consent"; // prompt 파라미터 추가
+
+        log.debug("Redirecting to: " + googleLoginUrl);
+        response.sendRedirect(googleLoginUrl);
+    }
+
+    // Google 및 Kakao 콜백 엔드포인트 통합
+    @GetMapping("/{provider}/callback")
+    public BaseResponse<MemberResponseDTO.JoinResultDTO> socialCallback(@PathVariable("provider") String provider,
+                                                                        @RequestParam("code") String accessCode,
+                                                                        HttpServletResponse httpServletResponse) {
+        Member member;
+        if ("google".equalsIgnoreCase(provider)) {
+            // 구글 로그인 처리
+            try {
+                // Authorization Code로 Access Token 가져오기
+                String googleAccessToken = googleUtil.getAccessToken(accessCode);
+
+                // Access Token으로 사용자 정보 가져오기
+                GoogleUserInfo userInfo = googleUtil.getUserInfo(googleAccessToken);
+
+                // AuthService로 회원 처리 (쿠키 설정 포함)
+                member = authService.googleLogin(userInfo, httpServletResponse);
+            } catch (Exception e) {
+                log.error("Google Callback Error: {}", e.getMessage());
+                throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+            }
+        } else if ("kakao".equalsIgnoreCase(provider)) {
+            // 카카오 로그인 처리
+            member = authService.kakaoLogin(accessCode, httpServletResponse);
+        } else {
+            throw new AuthHandler(ErrorStatus._INVALID_PROVIDER);
+        }
+        return BaseResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
+    }
+
+    // Refresh Token을 이용해 Access Token 갱신 엔드포인트 통합
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestBody Map<String, String> request, HttpServletResponse response) {
+        String refreshToken = request.get("refreshToken");
+        try {
+            String newAccessToken = authService.refreshAccessToken(refreshToken);
+            String email = jwtUtil.getEmailFromRefreshToken(refreshToken);
+            String newRefreshToken = jwtUtil.createRefreshToken(email);
+
+            // 새로운 토큰을 HttpOnly 쿠키에 설정
+            setCookie(response, "accessToken", newAccessToken, jwtUtil.getAccessTokenValiditySeconds());
+            setCookie(response, "refreshToken", newRefreshToken, jwtUtil.getRefreshTokenValiditySeconds());
+
+            return ResponseEntity.ok(Map.of(
+                    "accessToken", newAccessToken,
+                    "refreshToken", newRefreshToken
+            ));
+        } catch (AuthHandler e) {
+            log.error("Refresh Token Error: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    // 단일 통합 로그아웃 엔드포인트
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String authorization, HttpServletResponse response) {
+        try {
+            // 헤더에서 Access Token 추출
+            if (authorization == null || !authorization.startsWith("Bearer ")) {
+                throw new AuthHandler(ErrorStatus._TOKEN_NOT_FOUND);
+            }
+            String accessToken = authorization.split(" ")[1];
+
+            // Access Token에서 이메일 추출
+            String email = jwtUtil.getEmail(accessToken);
+
+            // 사용자 토큰 삭제 및 로그아웃 처리 (서비스 레이어에서 처리)
+            authService.revokeAndDeleteToken(email);
+
+            // HttpOnly 쿠키 삭제
+            deleteCookie(response, "accessToken");
+            deleteCookie(response, "refreshToken");
+
+            return ResponseEntity.ok(Map.of(
+                    "message", "Successfully logged out"
+            ));
+        } catch (AuthHandler e) {
+            log.error("Logout Error: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    // 쿠키 설정 메서드
+    private void setCookie(HttpServletResponse response, String name, String value, long maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // 프로덕션에서는 true로 설정
+        cookie.setPath("/");
+        cookie.setMaxAge((int) maxAge);
+        response.addCookie(cookie);
+    }
+
+    // 쿠키 삭제 메서드
+    private void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // 프로덕션에서는 true로 설정
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 삭제
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/edu/example/wayfarer/converter/AuthConverter.java
+++ b/src/main/java/edu/example/wayfarer/converter/AuthConverter.java
@@ -1,0 +1,18 @@
+package edu.example.wayfarer.converter;
+
+
+import edu.example.wayfarer.entity.Member;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class AuthConverter {
+
+    public static Member toUser(String email, String nickname,String profileImage, String password, PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .email(email)
+                .role("ROLE_USER")
+                .password(passwordEncoder.encode(password))
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .build();
+    }
+}

--- a/src/main/java/edu/example/wayfarer/converter/MemberConverter.java
+++ b/src/main/java/edu/example/wayfarer/converter/MemberConverter.java
@@ -1,0 +1,48 @@
+package edu.example.wayfarer.converter;
+
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.dto.member.MemberRequestDTO;
+import edu.example.wayfarer.dto.member.MemberResponseDTO;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+public class MemberConverter {
+
+    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO, PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .nickname(joinDTO.getNickname())
+                .password(passwordEncoder.encode(joinDTO.getPassword()))
+                .email(joinDTO.getEmail())
+                .profileImage(joinDTO.getProfileImage())
+                .role(joinDTO.getRole())
+                .build();
+    }
+
+    public static MemberResponseDTO.JoinResultDTO toJoinResultDTO(Member member) {
+        return MemberResponseDTO.JoinResultDTO.builder()
+                .email(member.getEmail())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberPreviewDTO toMemberPreviewDTO(Member member) {
+        return MemberResponseDTO.MemberPreviewDTO.builder()
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImage(member.getProfileImage())
+                .updatedAt(member.getUpdatedAt())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
+        List<MemberResponseDTO.MemberPreviewDTO> memberPreviewDTOList = memberList.stream()
+                                                                    .map(MemberConverter::toMemberPreviewDTO)
+                                                                    .toList();
+
+        return MemberResponseDTO.MemberPreviewListDTO.builder()
+                .memberPreviewDTOList(memberPreviewDTOList)
+                .build();
+    }
+}

--- a/src/main/java/edu/example/wayfarer/dto/GoogleUserInfo.java
+++ b/src/main/java/edu/example/wayfarer/dto/GoogleUserInfo.java
@@ -1,0 +1,13 @@
+package edu.example.wayfarer.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GoogleUserInfo {
+    private String email;
+    private String name;
+    private String picture;
+    private String googleAccessToken;
+}

--- a/src/main/java/edu/example/wayfarer/dto/KakaoDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/KakaoDTO.java
@@ -1,0 +1,59 @@
+package edu.example.wayfarer.dto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class KakaoDTO {
+
+    @Getter
+    @Setter
+    public static class OAuthToken {
+        private String access_token;
+        private String token_type;
+        private String refresh_token;
+        private int expires_in;
+        private String scope;
+        private int refresh_token_expires_in;
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoProfile {
+        private Long id;
+        private String connected_at;
+        private Properties properties;
+        private KakaoAccount kakao_account;
+
+        @Getter
+        @Setter
+        public static class Properties {
+            private String nickname;
+            private String profile_image;
+            private String thumbnail_image;
+        }
+
+        @Getter
+        @Setter
+        public static class KakaoAccount {
+            private String email;
+            private Boolean is_email_verified;
+            private Boolean has_email;
+            private Boolean profile_nickname_needs_agreement;
+            private Boolean profile_image_needs_agreement;
+            private Boolean email_needs_agreement;
+            private Boolean is_email_valid;
+            private Profile profile;
+
+            @Getter
+            @Setter
+            public static class Profile {
+                private String nickname;
+                private Boolean is_default_nickname;
+                private String thumbnail_image_url;
+                private String profile_image_url;
+                private Boolean is_default_image;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/example/wayfarer/dto/member/MemberRequestDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/member/MemberRequestDTO.java
@@ -1,0 +1,28 @@
+package edu.example.wayfarer.dto.member;
+
+
+import lombok.Getter;
+
+
+public class MemberRequestDTO {
+
+    @Getter
+    public static class JoinDTO {
+        private String nickname;
+        private String email;
+        private String password;
+        private String role;
+        private String profileImage;
+    }
+
+    @Getter
+    public static class UpdateMemberDTO {
+        private String nickname;
+    }
+
+    @Getter
+    public static class LoginRequestDTO {
+        private String email;
+        private String password;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/dto/member/MemberResponseDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/member/MemberResponseDTO.java
@@ -1,0 +1,41 @@
+package edu.example.wayfarer.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MemberResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class JoinResultDTO {
+        private String email;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class MemberPreviewDTO {
+        private String email;
+        private String nickname;
+        private String profileImage;
+        private LocalDateTime updatedAt;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class MemberPreviewListDTO {
+        List<MemberPreviewDTO> memberPreviewDTOList;
+    }
+}

--- a/src/main/java/edu/example/wayfarer/entity/Member.java
+++ b/src/main/java/edu/example/wayfarer/entity/Member.java
@@ -1,13 +1,12 @@
 package edu.example.wayfarer.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -21,16 +20,36 @@ import java.util.List;
 @Entity
 public class Member {
     @Id
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     private String nickname;
     private String profileImage;
     private String password;
     private String role;    // jwt에서의 role
+
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "member")
     private List<MemberRoom> memberRooms;
 
+    public void update(String nickname) {
+        this.nickname = nickname;
+    }
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "email='" + email + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", profileImage='" + profileImage + '\'' +
+                ", role='" + role + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
+    }
 }

--- a/src/main/java/edu/example/wayfarer/entity/Token.java
+++ b/src/main/java/edu/example/wayfarer/entity/Token.java
@@ -1,0 +1,57 @@
+package edu.example.wayfarer.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class Token {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자와의 연관관계 설정 (OneToOne)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "email", nullable = false, unique = true)
+    private Member member;
+
+    @Column(nullable = false, unique = true)
+    private String accessToken;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private LocalDateTime accessTokenExpiryDate;
+
+    @Column(nullable = false)
+    private LocalDateTime refreshTokenExpiryDate;
+
+    // 변경된 필드: Social Access Token
+    @Column(nullable = true, unique = true)
+    private String socialAccessToken;
+
+    // 추가된 필드: 소셜 제공자 구분 (예: "google", "kakao")
+    @Column(nullable = false)
+    private String provider;
+
+    // JWT 토큰 업데이트 메서드
+    public void updateJwtTokens(String newAccessToken, LocalDateTime newAccessTokenExpiryDate,
+                                String newRefreshToken, LocalDateTime newRefreshTokenExpiryDate) {
+        this.accessToken = newAccessToken;
+        this.accessTokenExpiryDate = newAccessTokenExpiryDate;
+        this.refreshToken = newRefreshToken;
+        this.refreshTokenExpiryDate = newRefreshTokenExpiryDate;
+    }
+
+    // Social Access Token 업데이트 메서드
+    public void updateSocialAccessToken(String newSocialAccessToken) {
+        this.socialAccessToken = newSocialAccessToken;
+    }
+
+}

--- a/src/main/java/edu/example/wayfarer/repository/MemberRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/MemberRepository.java
@@ -1,9 +1,10 @@
 package edu.example.wayfarer.repository;
 
 import edu.example.wayfarer.entity.Member;
-import edu.example.wayfarer.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/edu/example/wayfarer/repository/TokenRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/TokenRepository.java
@@ -1,0 +1,13 @@
+package edu.example.wayfarer.repository;
+
+import edu.example.wayfarer.entity.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(String refreshToken);
+    Optional<Token> findByMember_Email(String email);
+    Optional<Token> findBySocialAccessToken(String socialAccessToken);
+    void deleteByMember_Email(String email);
+}

--- a/src/main/java/edu/example/wayfarer/service/AuthService.java
+++ b/src/main/java/edu/example/wayfarer/service/AuthService.java
@@ -1,0 +1,13 @@
+package edu.example.wayfarer.service;
+
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.dto.GoogleUserInfo;
+import edu.example.wayfarer.entity.Member;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface AuthService {
+    Member googleLogin(GoogleUserInfo userInfo, HttpServletResponse httpServletResponse);
+    Member kakaoLogin(String accessCode, HttpServletResponse httpServletResponse);
+    String refreshAccessToken(String refreshToken);
+    void revokeAndDeleteToken(String email) throws AuthHandler;
+}

--- a/src/main/java/edu/example/wayfarer/service/AuthServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/AuthServiceImpl.java
@@ -1,0 +1,225 @@
+package edu.example.wayfarer.service;
+
+import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
+import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
+import edu.example.wayfarer.auth.util.GoogleUtil;
+import edu.example.wayfarer.auth.util.JwtUtil;
+import edu.example.wayfarer.auth.util.KakaoUtil;
+import edu.example.wayfarer.converter.AuthConverter;
+import edu.example.wayfarer.dto.GoogleUserInfo;
+import edu.example.wayfarer.entity.Member;
+import edu.example.wayfarer.dto.KakaoDTO;
+import edu.example.wayfarer.entity.Token;
+import edu.example.wayfarer.repository.MemberRepository;
+import edu.example.wayfarer.repository.TokenRepository;
+import edu.example.wayfarer.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+    private final KakaoUtil kakaoUtil;
+    private final GoogleUtil googleUtil;
+    private final MemberRepository memberRepository;
+    private final TokenRepository tokenRepository;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Member kakaoLogin(String accessCode, HttpServletResponse httpServletResponse) {
+        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(accessCode);
+        KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
+
+        Optional<Member> queryUser = memberRepository.findByEmail(kakaoProfile.getKakao_account().getEmail());
+
+        Member member;
+        if (queryUser.isPresent()) {
+            member = queryUser.get();
+        } else {
+            String randomPassword = UUID.randomUUID().toString();
+            member = AuthConverter.toUser(
+                    kakaoProfile.getKakao_account().getEmail(),
+                    kakaoProfile.getKakao_account().getProfile().getNickname(),
+                    kakaoProfile.getKakao_account().getProfile().getProfile_image_url(),
+                    randomPassword,
+                    passwordEncoder);
+            memberRepository.save(member);
+        }
+
+        // 기존 토큰 삭제
+        tokenRepository.deleteByMember_Email(member.getEmail());
+
+        // 새로운 Access Token과 Refresh Token 생성
+        String accessToken = jwtUtil.createAccessToken(member.getEmail(), member.getRole());
+        String refreshToken = jwtUtil.createRefreshToken(member.getEmail());
+
+        // 토큰 만료 시간 계산
+        LocalDateTime accessTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getAccessTokenValiditySeconds());
+        LocalDateTime refreshTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getRefreshTokenValiditySeconds());
+
+        // 토큰 저장
+        Token token = Token.builder()
+                .member(member)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .socialAccessToken(oAuthToken.getAccess_token())
+                .provider("kakao") // 소셜 제공자 설정
+                .accessTokenExpiryDate(accessTokenExpiryDate)
+                .refreshTokenExpiryDate(refreshTokenExpiryDate)
+                .build();
+        tokenRepository.save(token);
+
+        // JWT Access Token과 Refresh Token을 HttpOnly 쿠키에 설정
+        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(false); // 프로덕션에서는 true로 설정
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) jwtUtil.getAccessTokenValiditySeconds());
+        httpServletResponse.addCookie(accessTokenCookie);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(false); // 프로덕션에서는 true로 설정
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) jwtUtil.getRefreshTokenValiditySeconds());
+        httpServletResponse.addCookie(refreshTokenCookie);
+
+        return member;
+    }
+
+    @Override
+    public Member googleLogin(GoogleUserInfo userInfo, HttpServletResponse httpServletResponse) {
+        Optional<Member> queryUser = memberRepository.findByEmail(userInfo.getEmail());
+
+        Member member;
+        if (queryUser.isPresent()) {
+            member = queryUser.get();
+        } else {
+            String randomPassword = UUID.randomUUID().toString();
+            member = AuthConverter.toUser(
+                    userInfo.getEmail(),
+                    userInfo.getName(),
+                    userInfo.getPicture(),
+                    randomPassword,
+                    passwordEncoder);
+            memberRepository.save(member);
+        }
+
+        // 기존 토큰 삭제
+        tokenRepository.deleteByMember_Email(member.getEmail());
+
+        // 새로운 Access Token과 Refresh Token 생성
+        String accessToken = jwtUtil.createAccessToken(member.getEmail(), member.getRole());
+        String refreshToken = jwtUtil.createRefreshToken(member.getEmail());
+
+        // Google Access Token 가져오기
+        String googleAccessToken = userInfo.getGoogleAccessToken();
+
+        // 토큰 만료 시간 계산 (초 단위)
+        LocalDateTime accessTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getAccessTokenValiditySeconds());
+        LocalDateTime refreshTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getRefreshTokenValiditySeconds());
+
+        // 토큰 저장
+        Token token = Token.builder()
+                .member(member)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .socialAccessToken(googleAccessToken)
+                .provider("google")
+                .accessTokenExpiryDate(accessTokenExpiryDate)
+                .refreshTokenExpiryDate(refreshTokenExpiryDate)
+                .build();
+        tokenRepository.save(token);
+
+        // JWT Access Token과 Refresh Token을 HttpOnly 쿠키에 설정
+        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(false); // 프로덕션에서는 true로 설정
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) jwtUtil.getAccessTokenValiditySeconds());
+        httpServletResponse.addCookie(accessTokenCookie);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(false); // 프로덕션에서는 true로 설정
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge((int) jwtUtil.getRefreshTokenValiditySeconds());
+        httpServletResponse.addCookie(refreshTokenCookie);
+
+        return member;
+    }
+
+    @Override
+    public String refreshAccessToken(String refreshToken) {
+        // Refresh Token 유효성 검증
+        if (!jwtUtil.isRefreshTokenValid(refreshToken)) {
+            throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+        }
+
+        // Refresh Token으로 사용자 이메일 추출
+        String email = jwtUtil.getEmailFromRefreshToken(refreshToken);
+        Optional<Token> optionalToken = tokenRepository.findByRefreshToken(refreshToken);
+
+        if (optionalToken.isEmpty()) {
+            throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+        }
+
+        Token token = optionalToken.get();
+
+        // Refresh Token 만료 여부 확인
+        if (token.getRefreshTokenExpiryDate().isBefore(LocalDateTime.now())) {
+            throw new AuthHandler(ErrorStatus._AUTH_EXPIRE_TOKEN);
+        }
+
+        // 새로운 Access Token과 Refresh Token 생성
+        String newAccessToken = jwtUtil.createAccessToken(email, token.getMember().getRole());
+        String newRefreshToken = jwtUtil.createRefreshToken(email);
+
+        // 토큰 만료 시간 계산
+        LocalDateTime newAccessTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getAccessTokenValiditySeconds());
+        LocalDateTime newRefreshTokenExpiryDate = LocalDateTime.now().plusSeconds(jwtUtil.getRefreshTokenValiditySeconds());
+
+        // 기존 토큰 업데이트 (Social Access Token 및 Provider는 유지)
+        token.updateJwtTokens(newAccessToken, newAccessTokenExpiryDate, newRefreshToken, newRefreshTokenExpiryDate);
+        tokenRepository.save(token);
+
+        return newAccessToken;
+    }
+
+    @Override
+    public void revokeAndDeleteToken(String email) throws AuthHandler { // 로그아웃
+        // 사용자에게 할당된 토큰 조회
+        Optional<Token> optionalToken = tokenRepository.findByMember_Email(email);
+        if (optionalToken.isEmpty()) {
+            throw new AuthHandler(ErrorStatus._TOKEN_NOT_FOUND);
+        }
+
+        Token token = optionalToken.get();
+
+        String socialAccessToken = token.getSocialAccessToken();
+        String provider = token.getProvider();
+
+        if (socialAccessToken != null && !socialAccessToken.isEmpty()) {
+            if ("google".equalsIgnoreCase(provider)) {
+                // 구글 Access Token을 이용하여 로그아웃 처리 (토큰 폐기)
+                googleUtil.revokeToken(socialAccessToken);
+            } else if ("kakao".equalsIgnoreCase(provider)) {
+                // 카카오 Access Token을 이용하여 로그아웃 처리 (토큰 폐기)
+                kakaoUtil.revokeToken(socialAccessToken);
+            }
+        }
+
+        // 토큰 삭제
+        tokenRepository.delete(token);
+    }
+}


### PR DESCRIPTION
드디어 고대하고 고대하던 소셜 로그인이 굴러가는 PR을 갖고 왔습니다. (물론 굴렁쇠도 굴러가긴합니다만)

우선 로그인 및 회원가입을 위한 URL은 application.properties 파일 맨 밑에 작성해두었으니, 노션에서 확인해주시길 바랍니다.
로그아웃 하실 때는 select * from token -> access_token 필드를 예전에 했던 Talend API에서 "Bearer access_token"과 같은 형태로 BODY부분은 비워둔 채로 localhost:8080/auth/logout 에서 POST 요청 해주시면 됩니다. 

그리고 크게 변동 사항이 두 가지 있습니다. 
1. Member 엔티티에 약간 변동이 있습니다만, 필드값을 변동한 것은 아니라 아마 문제가 발생하지는 않을 것으로 예상됩니다.
2. Token 엔티티가 추가되었습니다. 따로 엔티티를 만들어놓지 않으면 하나의 Member에 대해 무한 로그인이 가능해지면서 , 로그인한 상태인지 로그아웃된 상태인지를 구분하는 것이 불가능해지기 때문에 이를 통제하기 위해서는 따로 Token엔티티를 빼놔야 한다고 하더라구요. 이렇게 함으로써 만약 하나의 Member가 로그인을 한번 하고, 다른 창에서 또 로그인을 했을 경우에 이전에 로그인했던 Token은 사라지고 방금 로그인한 Token이 새로 생성됩니다. 그럼 전에 생성해놓았던 페이지에서는 새로고침 했을시에 토큰값이 부적절하여 아무 행동도 취할 수 없게 됩니다.

앞으로 다음어야 할 부분도 있습니다.
1. DTO부분에 카카오와 구글 DTO가 지멋대로입니다. 구글은 제가 GPT와 씨름하면서 만든것이고 , 카카오는 다른 블로그에 있던 코드를 그대로 긁어온것이라 틀 자체가 아예 안맞는 상태라서 , 시간이 되면 카카오도 구글DTO형태로 다듬을 생각입니다.
2. apiPayload 디렉토리에 보면 exception을 비롯한 파일들이 작성되어있는데, 이것도 우리들의 최신 브랜치에서는 따로 디렉토리가 생성되어있어 중복되는 상태입니다. 이것도 수정가능하면 수정해놓겠습니다.
3.  AuthServiceImpl 코드를 확인해보시면 "프로덕션에서는 true로 설정" 라는 주석이 처리되어있는 부분이 있습니다. GPT한테 졸라서 나온 코드로 AWS에 올릴때는 true로 설정하라는 것으로 보이는데 정확하게 인지한 상태에서 갖다놓은 코드가 아니라서 다시 학습하여 저 부분이 필수라면 넣어두고 , 아니라면 빼놓도록 하겠습니다.

