### PR TITLE
카카오 로그인 리팩토링 완료

### DIFF
--- a/src/main/java/edu/example/wayfarer/auth/constant/SecurityConstants.java
+++ b/src/main/java/edu/example/wayfarer/auth/constant/SecurityConstants.java
@@ -13,6 +13,7 @@ public class SecurityConstants {
             "/auth/kakao/callback/**",
             "/auth/google/callback/**",
             "/auth/login/google", // 구글 경로 추가
+            "/auth/login/kakao",
             //"/login/oauth2/code/google", // OAuth 리다이렉트 경로 추가
             "/logout",
             "/refresh",

--- a/src/main/java/edu/example/wayfarer/controller/AuthController.java
+++ b/src/main/java/edu/example/wayfarer/controller/AuthController.java
@@ -1,18 +1,16 @@
 package edu.example.wayfarer.controller;
 
-import edu.example.wayfarer.apiPayload.BaseResponse;
 import edu.example.wayfarer.apiPayload.code.status.ErrorStatus;
 import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
-import edu.example.wayfarer.converter.MemberConverter;
+import edu.example.wayfarer.auth.util.KakaoUtil;
+import edu.example.wayfarer.dto.KakaoDTO;
 import edu.example.wayfarer.entity.Member;
 import edu.example.wayfarer.dto.GoogleUserInfo;
-import edu.example.wayfarer.dto.member.MemberResponseDTO;
 import edu.example.wayfarer.service.AuthService;
 import edu.example.wayfarer.auth.util.GoogleUtil;
 import edu.example.wayfarer.auth.util.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +34,7 @@ public class AuthController {
     private final AuthService authService;
     private final JwtUtil jwtUtil;
     private final GoogleUtil googleUtil;
+    private final KakaoUtil kakaoUtil;
 
     // Google 로그인 리다이렉트 엔드포인트
     @GetMapping("/login/google")
@@ -51,6 +50,19 @@ public class AuthController {
 
         log.debug("Redirecting to: " + googleLoginUrl);
         response.sendRedirect(googleLoginUrl);
+    }
+
+    @GetMapping("/login/kakao")
+    public void redirectToKakao(HttpServletResponse response,
+                                 @Value("${KAKAO_CLIENT_ID}") String clientId,
+                                 @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}") String redirectUri) throws IOException {
+        String kakaoLoginUrl = "https://kauth.kakao.com/oauth/authorize?"
+                + "client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
+                + "&response_type=code";
+
+        log.debug("Redirecting to: " + kakaoLoginUrl);
+        response.sendRedirect(kakaoLoginUrl);
     }
 
     // Google 및 Kakao 콜백 엔드포인트 통합
@@ -76,58 +88,24 @@ public class AuthController {
             }
         } else if ("kakao".equalsIgnoreCase(provider)) {
             // 카카오 로그인 처리
-            member = authService.kakaoLogin(accessCode, httpServletResponse);
+            try {
+                // AuthService로 회원 처리 (쿠키 설정 포함)
+                member = authService.kakaoLogin(accessCode, httpServletResponse);
+            } catch (Exception e) {
+                log.error("Kakao Callback Error: {}", e.getMessage());
+                throw new AuthHandler(ErrorStatus._AUTH_INVALID_TOKEN);
+            }
         } else {
             throw new AuthHandler(ErrorStatus._INVALID_PROVIDER);
         }
-        //return BaseResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
         try {
             // 로그인 성공 후 메인 페이지로 리다이렉트
-            httpServletResponse.sendRedirect("http://localhost:8080/");
+            httpServletResponse.sendRedirect("http://localhost:8080/"); //메인페이지
         } catch (IOException e) {
             log.error("Redirect Error: {}", e.getMessage());
             throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
     }
-
-//    @PostMapping("/refresh")
-//    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
-//        String refreshToken = getRefreshTokenFromCookies(request);
-//        if (refreshToken == null || refreshToken.isEmpty()) {
-//            log.error("Refresh Token not found in request");
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "Refresh Token not found"));
-//        }
-//
-//        try {
-//            String newAccessToken = authService.refreshAccessToken(refreshToken);
-//            String email = jwtUtil.getEmail(refreshToken);
-//            String newRefreshToken = jwtUtil.createRefreshToken(email);
-//
-//            // 새로운 Access Token과 Refresh Token을 HttpOnly 쿠키에 설정
-//            setCookie(response, "accessToken", newAccessToken, jwtUtil.getAccessTokenValiditySeconds());
-//            setCookie(response, "refreshToken", newRefreshToken, jwtUtil.getRefreshTokenValiditySeconds());
-//
-//            return ResponseEntity.ok(Map.of(
-//                    "accessToken", newAccessToken // Refresh Token은 쿠키에 저장되므로 응답 본문에 포함하지 않음
-//            ));
-//        } catch (AuthHandler e) {
-//            log.error("Refresh Token Error: {}", e.getMessage());
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
-//                    "message", e.getMessage()
-//            ));
-//        }
-//    }
-//
-//    // 쿠키에서 Refresh Token 추출 메서드 추가
-//    private String getRefreshTokenFromCookies(HttpServletRequest request) {
-//        if (request.getCookies() == null) return null;
-//        for (Cookie cookie : request.getCookies()) {
-//            if ("refreshToken".equals(cookie.getName())) {
-//                return cookie.getValue();
-//            }
-//        }
-//        return null;
-//    }
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String authorization, HttpServletResponse response) {
@@ -155,7 +133,7 @@ public class AuthController {
             // 사용자 토큰 삭제 및 로그아웃 처리 (서비스 레이어에서 처리)
             authService.revokeAndDeleteToken(email);
 
-            // HttpOnly 쿠키 삭제
+            // HttpOnly 쿠키 삭제 -> 시크릿창은 이 코드 무시해버림
             deleteCookie(response, "accessToken");
             deleteCookie(response, "refreshToken");
 

--- a/src/main/java/edu/example/wayfarer/converter/MemberConverter.java
+++ b/src/main/java/edu/example/wayfarer/converter/MemberConverter.java
@@ -1,48 +1,48 @@
-package edu.example.wayfarer.converter;
-
-import edu.example.wayfarer.entity.Member;
-import edu.example.wayfarer.dto.member.MemberRequestDTO;
-import edu.example.wayfarer.dto.member.MemberResponseDTO;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.List;
-
-public class MemberConverter {
-
-    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO, PasswordEncoder passwordEncoder) {
-        return Member.builder()
-                .nickname(joinDTO.getNickname())
-                .password(passwordEncoder.encode(joinDTO.getPassword()))
-                .email(joinDTO.getEmail())
-                .profileImage(joinDTO.getProfileImage())
-                .role(joinDTO.getRole())
-                .build();
-    }
-
-    public static MemberResponseDTO.JoinResultDTO toJoinResultDTO(Member member) {
-        return MemberResponseDTO.JoinResultDTO.builder()
-                .email(member.getEmail())
-                .createdAt(member.getCreatedAt())
-                .build();
-    }
-
-    public static MemberResponseDTO.MemberPreviewDTO toMemberPreviewDTO(Member member) {
-        return MemberResponseDTO.MemberPreviewDTO.builder()
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .profileImage(member.getProfileImage())
-                .updatedAt(member.getUpdatedAt())
-                .createdAt(member.getCreatedAt())
-                .build();
-    }
-
-    public static MemberResponseDTO.MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
-        List<MemberResponseDTO.MemberPreviewDTO> memberPreviewDTOList = memberList.stream()
-                                                                    .map(MemberConverter::toMemberPreviewDTO)
-                                                                    .toList();
-
-        return MemberResponseDTO.MemberPreviewListDTO.builder()
-                .memberPreviewDTOList(memberPreviewDTOList)
-                .build();
-    }
-}
+//package edu.example.wayfarer.converter;
+//
+//import edu.example.wayfarer.entity.Member;
+//import edu.example.wayfarer.dto.member.MemberRequestDTO;
+//import edu.example.wayfarer.dto.member.MemberResponseDTO;
+//import org.springframework.security.crypto.password.PasswordEncoder;
+//
+//import java.util.List;
+//
+//public class MemberConverter {
+//
+//    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO, PasswordEncoder passwordEncoder) {
+//        return Member.builder()
+//                .nickname(joinDTO.getNickname())
+//                .password(passwordEncoder.encode(joinDTO.getPassword()))
+//                .email(joinDTO.getEmail())
+//                .profileImage(joinDTO.getProfileImage())
+//                .role(joinDTO.getRole())
+//                .build();
+//    }
+//
+//    public static MemberResponseDTO.JoinResultDTO toJoinResultDTO(Member member) {
+//        return MemberResponseDTO.JoinResultDTO.builder()
+//                .email(member.getEmail())
+//                .createdAt(member.getCreatedAt())
+//                .build();
+//    }
+//
+//    public static MemberResponseDTO.MemberPreviewDTO toMemberPreviewDTO(Member member) {
+//        return MemberResponseDTO.MemberPreviewDTO.builder()
+//                .email(member.getEmail())
+//                .nickname(member.getNickname())
+//                .profileImage(member.getProfileImage())
+//                .updatedAt(member.getUpdatedAt())
+//                .createdAt(member.getCreatedAt())
+//                .build();
+//    }
+//
+//    public static MemberResponseDTO.MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
+//        List<MemberResponseDTO.MemberPreviewDTO> memberPreviewDTOList = memberList.stream()
+//                                                                    .map(MemberConverter::toMemberPreviewDTO)
+//                                                                    .toList();
+//
+//        return MemberResponseDTO.MemberPreviewListDTO.builder()
+//                .memberPreviewDTOList(memberPreviewDTOList)
+//                .build();
+//    }
+//}

--- a/src/main/java/edu/example/wayfarer/dto/member/MemberRequestDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/member/MemberRequestDTO.java
@@ -1,28 +1,28 @@
-package edu.example.wayfarer.dto.member;
-
-
-import lombok.Getter;
-
-
-public class MemberRequestDTO {
-
-    @Getter
-    public static class JoinDTO {
-        private String nickname;
-        private String email;
-        private String password;
-        private String role;
-        private String profileImage;
-    }
-
-    @Getter
-    public static class UpdateMemberDTO {
-        private String nickname;
-    }
-
-    @Getter
-    public static class LoginRequestDTO {
-        private String email;
-        private String password;
-    }
-}
+//package edu.example.wayfarer.dto.member;
+//
+//
+//import lombok.Getter;
+//
+//
+//public class MemberRequestDTO {
+//
+//    @Getter
+//    public static class JoinDTO {
+//        private String nickname;
+//        private String email;
+//        private String password;
+//        private String role;
+//        private String profileImage;
+//    }
+//
+//    @Getter
+//    public static class UpdateMemberDTO {
+//        private String nickname;
+//    }
+//
+//    @Getter
+//    public static class LoginRequestDTO {
+//        private String email;
+//        private String password;
+//    }
+//}

--- a/src/main/java/edu/example/wayfarer/dto/member/MemberResponseDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/member/MemberResponseDTO.java
@@ -1,41 +1,41 @@
-package edu.example.wayfarer.dto.member;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-public class MemberResponseDTO {
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class JoinResultDTO {
-        private String email;
-        private LocalDateTime createdAt;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class MemberPreviewDTO {
-        private String email;
-        private String nickname;
-        private String profileImage;
-        private LocalDateTime updatedAt;
-        private LocalDateTime createdAt;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class MemberPreviewListDTO {
-        List<MemberPreviewDTO> memberPreviewDTOList;
-    }
-}
+//package edu.example.wayfarer.dto.member;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//import java.time.LocalDateTime;
+//import java.util.List;
+//
+//public class MemberResponseDTO {
+//
+//    @Getter
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    @Builder
+//    public static class JoinResultDTO {
+//        private String email;
+//        private LocalDateTime createdAt;
+//    }
+//
+//    @Getter
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    @Builder
+//    public static class MemberPreviewDTO {
+//        private String email;
+//        private String nickname;
+//        private String profileImage;
+//        private LocalDateTime updatedAt;
+//        private LocalDateTime createdAt;
+//    }
+//
+//    @Getter
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    @Builder
+//    public static class MemberPreviewListDTO {
+//        List<MemberPreviewDTO> memberPreviewDTOList;
+//    }
+//}

--- a/src/main/java/edu/example/wayfarer/service/AuthService.java
+++ b/src/main/java/edu/example/wayfarer/service/AuthService.java
@@ -2,6 +2,7 @@ package edu.example.wayfarer.service;
 
 import edu.example.wayfarer.apiPayload.exception.handler.AuthHandler;
 import edu.example.wayfarer.dto.GoogleUserInfo;
+import edu.example.wayfarer.dto.KakaoDTO;
 import edu.example.wayfarer.entity.Member;
 import jakarta.servlet.http.HttpServletResponse;
 


### PR DESCRIPTION
카카오 소셜로그인이 너무 스파게티 코드로 짜져있어서 리팩토링을 진행하였습니다.

구글처럼 깔끔하게 카카오도 필요한 정보만 갖고오게 하려고 수정작업을 시작하였으나 오히려 그 작업이 훨씬 복잡하여 그냥 모든 정보를 갖고 온뒤에 선별하는 것으로 기존 코드 유지하는 방법을 선택하였습니다.

(작업 중간에 member관련 converter나 다른 코드를 주석처리했었는데 이건 다시 풀겠습니다)