### PR TITLE
Feat/#118/레디스 설정 및 chatmessage저장

### DIFF
--- a/src/main/java/edu/example/wayfarer/WayfarerApplication.java
+++ b/src/main/java/edu/example/wayfarer/WayfarerApplication.java
@@ -4,12 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
+@EnableCaching
 public class WayfarerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/edu/example/wayfarer/WayfarerApplication.java
+++ b/src/main/java/edu/example/wayfarer/WayfarerApplication.java
@@ -7,11 +7,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
 @EnableCaching
+@EnableScheduling
 public class WayfarerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/edu/example/wayfarer/config/RedisConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/RedisConfig.java
@@ -1,15 +1,23 @@
 package edu.example.wayfarer.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
 
 @Configuration
 public class RedisConfig {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -29,4 +37,15 @@ public class RedisConfig {
         template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
         return template;
     }
+
+    @Bean(name = "jsonRedisTemplate")
+    public RedisTemplate<String, Object> jsonRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        template.afterPropertiesSet();
+        return template;
+    }
+
 }

--- a/src/main/java/edu/example/wayfarer/converter/ChatMessageConverter.java
+++ b/src/main/java/edu/example/wayfarer/converter/ChatMessageConverter.java
@@ -13,19 +13,13 @@ import java.util.Locale;
 public class ChatMessageConverter {
 
     public static ChatMessage toChatMessage(Room room, Member member,String content, String timestamp) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss.SSS z yyyy", Locale.ENGLISH);
-
-        // KST를 Asia/Seoul로 바꿔서 파싱
-        timestamp = timestamp.replace("KST", "Asia/Seoul");
-
-        // ZonedDateTime을 사용하여 시간대 정보를 포함한 파싱
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse(timestamp, formatter);
+        LocalDateTime time = stringTOLocalDateTime(timestamp);
 
         return ChatMessage.builder()
                 .room(room)
                 .member(member)
                 .content(content)
-                .createdAt(zonedDateTime.toLocalDateTime())
+                .createdAt(time)
                 .build();
     }
 
@@ -34,9 +28,21 @@ public class ChatMessageConverter {
                 chatMessage.getRoom().getRoomId(),
                 chatMessage.getMember().getEmail(),
                 chatMessage.getContent(),
-                chatMessage.getCreatedAt(),
-                chatMessage.getUpdatedAt()
+                chatMessage.getCreatedAt()
         );
+
+    }
+
+    public static LocalDateTime stringTOLocalDateTime(String timestamp) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss.SSS z yyyy", Locale.ENGLISH);
+
+        // KST를 Asia/Seoul로 바꿔서 파싱
+        timestamp = timestamp.replace("KST", "Asia/Seoul");
+
+        // ZonedDateTime을 사용하여 시간대 정보를 포함한 파싱
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(timestamp, formatter);
+
+        return zonedDateTime.toLocalDateTime();
 
     }
 }

--- a/src/main/java/edu/example/wayfarer/converter/ChatMessageConverter.java
+++ b/src/main/java/edu/example/wayfarer/converter/ChatMessageConverter.java
@@ -1,18 +1,31 @@
 package edu.example.wayfarer.converter;
 
-import edu.example.wayfarer.dto.chatMessage.ChatMessageRequestDTO;
 import edu.example.wayfarer.dto.chatMessage.ChatMessageResponseDTO;
 import edu.example.wayfarer.entity.ChatMessage;
 import edu.example.wayfarer.entity.Member;
 import edu.example.wayfarer.entity.Room;
 
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
 public class ChatMessageConverter {
 
-    public static ChatMessage toChatMessage(Room room, Member member,String content) {
+    public static ChatMessage toChatMessage(Room room, Member member,String content, String timestamp) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss.SSS z yyyy", Locale.ENGLISH);
+
+        // KST를 Asia/Seoul로 바꿔서 파싱
+        timestamp = timestamp.replace("KST", "Asia/Seoul");
+
+        // ZonedDateTime을 사용하여 시간대 정보를 포함한 파싱
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(timestamp, formatter);
+
         return ChatMessage.builder()
                 .room(room)
                 .member(member)
                 .content(content)
+                .createdAt(zonedDateTime.toLocalDateTime())
                 .build();
     }
 

--- a/src/main/java/edu/example/wayfarer/dto/chatMessage/ChatMessageRequestDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/chatMessage/ChatMessageRequestDTO.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ChatMessageRequestDTO(
         String roomId,
         String email,
-        String content
+        String content,
+        String timestamp
 ) {
 }

--- a/src/main/java/edu/example/wayfarer/dto/chatMessage/ChatMessageResponseDTO.java
+++ b/src/main/java/edu/example/wayfarer/dto/chatMessage/ChatMessageResponseDTO.java
@@ -6,7 +6,6 @@ public record ChatMessageResponseDTO(
         String roomId,
         String email,
         String content,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/edu/example/wayfarer/entity/ChatMessage.java
+++ b/src/main/java/edu/example/wayfarer/entity/ChatMessage.java
@@ -35,7 +35,6 @@ public class ChatMessage {
 
 //    private MessageType messageType;
 
-    @CreationTimestamp
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/edu/example/wayfarer/handler/ChatHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/ChatHandler.java
@@ -85,10 +85,6 @@ public class ChatHandler {
         jsonRedisTemplate.opsForList().rightPush(CHAT_CACHE_PREFIX + roomId, broadcastMessage);
         jsonRedisTemplate.expire(CHAT_CACHE_PREFIX + roomId, 1, TimeUnit.DAYS);
 
-        //chatMessage DB에 저장
-//        ChatMessageRequestDTO chatMessageRequestDTO = new ChatMessageRequestDTO (roomId, email, message);
-//        chatMessageService.createChatMessage(chatMessageRequestDTO);
-
         log.debug("BROADCAST_MESSAGE: " + broadcastMessage);
 
         template.convertAndSend("/topic/room/" + roomId, broadcastMessage);

--- a/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
@@ -25,28 +25,37 @@ public class RedisHandler {
     private final RedisTemplate<String, Object> jsonRedisTemplate;
     private final ChatMessageService chatMessageService;
 
-    @Scheduled(fixedRate = 60000)
+    // 12시간에 한번씩 DB에 저장 (배포용)
+    //@Scheduled(fixedRate = 43200000)
+
+    // 60초에 한번씩 DB에 저장 (테스트용)
+    @Scheduled(fixedRate = 600000)
     public void migrateMessagesTODB() {
         log.info("Starting Redis to DB migration...");
 
+        //Redis 에서 ChatMessage: 로 시작하는 모든 key 값 검색
         Set<String> keys = jsonRedisTemplate.keys(CHAT_CACHE_PREFIX+"*");
         log.debug("Found keys: {}", keys);
+        //key 값이 존재하지 않으면, DB에 저장할 데이터가 없으므로 메서드 종료
         if (keys == null || keys.isEmpty()) {
             log.info("No keys found in Redis.");
             log.info("Migration complete.");
             return;
         }
 
+        // 각 key 값 마다 List 형태로 된 value 조회
         for (String key : keys) {
             List<Object> messageList = jsonRedisTemplate.opsForList().range(key, 0, -1);
             log.debug("messageList: {}", messageList);
 
+            //List 내부에 있는 각각의 메시지는 Map 형태로 존재
             for (Object message : messageList) {
                 if (!(message instanceof Map<?,?> messageData)) {
                     log.error("Unexpected message data format in key: {}", key);
                     throw new RedisException("Unexpected message data format in key");
                 }
 
+                //메시지에서 정보 추출
                 Map<?, ?> data = (Map<?, ?>) messageData.get("data");
 
                 String roomId = key.split(":")[1];
@@ -63,6 +72,7 @@ public class RedisHandler {
                     chatMessageService.createChatMessage(chatMessageRequestDTO);
                     log.info("Message saved to DB: roomId={}, email={}, content={}", roomId, email, content);
                 } else {
+                    //중복된 DB는 저장하지 않고 로그에 표시
                     log.info("Message already exists in DB: roomId={}, email={}, content={}", roomId, email, content);
                 }
             }

--- a/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
@@ -29,7 +29,10 @@ public class RedisHandler {
     //@Scheduled(fixedRate = 43200000)
 
     // 60초에 한번씩 DB에 저장 (테스트용)
-    @Scheduled(fixedRate = 600000)
+    //@Scheduled(fixedRate = 60000)
+
+    // 12시간에 한번씩 DB에 저장 (배포용)
+    @Scheduled(fixedRate = 43200000)
     public void migrateMessagesTODB() {
         log.info("Starting Redis to DB migration...");
 

--- a/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
@@ -30,7 +30,7 @@ public class RedisHandler {
         log.info("Starting Redis to DB migration...");
 
         Set<String> keys = jsonRedisTemplate.keys(CHAT_CACHE_PREFIX+"*");
-        log.info("Found keys: {}", keys);
+        log.debug("Found keys: {}", keys);
         if (keys == null || keys.isEmpty()) {
             log.info("No keys found in Redis.");
             log.info("Migration complete.");
@@ -39,7 +39,7 @@ public class RedisHandler {
 
         for (String key : keys) {
             List<Object> messageList = jsonRedisTemplate.opsForList().range(key, 0, -1);
-            log.info("messageList: {}", messageList);
+            log.debug("messageList: {}", messageList);
 
             for (Object message : messageList) {
                 if (!(message instanceof Map<?,?> messageData)) {
@@ -66,8 +66,6 @@ public class RedisHandler {
                     log.info("Message already exists in DB: roomId={}, email={}, content={}", roomId, email, content);
                 }
             }
-            jsonRedisTemplate.delete(key);
-            log.info("Redis Key deleted");
         }
         log.info("Migration complete.");
     }

--- a/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/RedisHandler.java
@@ -1,0 +1,74 @@
+package edu.example.wayfarer.handler;
+
+import edu.example.wayfarer.dto.chatMessage.ChatMessageRequestDTO;
+import edu.example.wayfarer.service.ChatMessageService;
+import io.lettuce.core.RedisException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static edu.example.wayfarer.handler.ChatHandler.CHAT_CACHE_PREFIX;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class RedisHandler {
+
+    @Qualifier("jsonRedisTemplate")
+    private final RedisTemplate<String, Object> jsonRedisTemplate;
+    private final ChatMessageService chatMessageService;
+
+    @Scheduled(fixedRate = 60000)
+    public void migrateMessagesTODB() {
+        log.info("Starting Redis to DB migration...");
+
+        Set<String> keys = jsonRedisTemplate.keys(CHAT_CACHE_PREFIX+"*");
+        log.info("Found keys: {}", keys);
+        if (keys == null || keys.isEmpty()) {
+            log.info("No keys found in Redis.");
+            log.info("Migration complete.");
+            return;
+        }
+
+        for (String key : keys) {
+            List<Object> messageList = jsonRedisTemplate.opsForList().range(key, 0, -1);
+            log.info("messageList: {}", messageList);
+
+            for (Object message : messageList) {
+                if (!(message instanceof Map<?,?> messageData)) {
+                    log.error("Unexpected message data format in key: {}", key);
+                    throw new RedisException("Unexpected message data format in key");
+                }
+
+                Map<?, ?> data = (Map<?, ?>) messageData.get("data");
+
+                String roomId = key.split(":")[1];
+                String email = (String) data.get("sender");
+                String content = (String) data.get("message");
+                String timestamp = (String) data.get("timestamp");
+
+                // ChatMessageRequestDTO 객체 생성
+                ChatMessageRequestDTO chatMessageRequestDTO = new ChatMessageRequestDTO(roomId, email, content, timestamp);
+
+                // Redis 데이터가 이미 DB에 저장된 메시지인지 확인
+                if (!chatMessageService.isMessageExistsInDB(chatMessageRequestDTO)) {
+                    // 필터링된 메시지들만 DB에 저장
+                    chatMessageService.createChatMessage(chatMessageRequestDTO);
+                    log.info("Message saved to DB: roomId={}, email={}, content={}", roomId, email, content);
+                } else {
+                    log.info("Message already exists in DB: roomId={}, email={}, content={}", roomId, email, content);
+                }
+            }
+            jsonRedisTemplate.delete(key);
+            log.info("Redis Key deleted");
+        }
+        log.info("Migration complete.");
+    }
+}

--- a/src/main/java/edu/example/wayfarer/repository/ChatMessageRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/ChatMessageRepository.java
@@ -6,15 +6,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.messaging.handler.annotation.Payload;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    @Query("SELECT new edu.example.wayfarer.dto.chatMessage.ChatMessageResponseDTO(cm.room.roomId, cm.member.email, cm.content, cm.createdAt, cm.updatedAt) " +
+    @Query("SELECT new edu.example.wayfarer.dto.chatMessage.ChatMessageResponseDTO(cm.room.roomId, cm.member.email, cm.content, cm.createdAt) " +
             "FROM ChatMessage cm " +
             "WHERE cm.room.roomId = :roomId")
     List<ChatMessageResponseDTO> findChatMessageResponseDTOByRoomId(String roomId);
+
+    @Query("SELECT new edu.example.wayfarer.dto.chatMessage.ChatMessageResponseDTO(cm.room.roomId, cm.member.email, cm.content, cm.createdAt)" +
+            "FROM ChatMessage cm " +
+            "WHERE cm.room.roomId = :roomId AND cm.createdAt < :createdAt ORDER BY cm.createdAt DESC")
+    List<ChatMessageResponseDTO> findChatMessageResponseDTOByRoomIdBeforeCreatedAt(
+            @Param("roomId") String roomId,
+            @Param("createdAt") LocalDateTime createdAt);
 
     @Modifying
     @Query("DELETE FROM ChatMessage c WHERE c.room.roomId = :roomId")

--- a/src/main/java/edu/example/wayfarer/repository/ChatMessageRepository.java
+++ b/src/main/java/edu/example/wayfarer/repository/ChatMessageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -18,4 +19,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Modifying
     @Query("DELETE FROM ChatMessage c WHERE c.room.roomId = :roomId")
     void deleteByRoomId(@Param("roomId") String roomId);
+
+    boolean existsByRoom_RoomIdAndMemberEmailAndCreatedAt(String roomId, String sender, LocalDateTime createdAt);
 }

--- a/src/main/java/edu/example/wayfarer/service/ChatMessageService.java
+++ b/src/main/java/edu/example/wayfarer/service/ChatMessageService.java
@@ -4,6 +4,7 @@ import edu.example.wayfarer.dto.chatMessage.ChatMessageRequestDTO;
 import edu.example.wayfarer.dto.chatMessage.ChatMessageResponseDTO;
 import edu.example.wayfarer.dto.chatMessage.ChatMessageUpdateDTO;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageService {
@@ -16,6 +17,11 @@ public interface ChatMessageService {
 
     List<ChatMessageResponseDTO> getChatMessageListDTOByRoomId(String roomId);
 
+    List<ChatMessageResponseDTO> getChatMessagesBeforeTimestamp(String roomId, LocalDateTime createdAt);
+
     boolean isMessageExistsInDB(ChatMessageRequestDTO chatMessageRequestDTO);
+
+
+
 
 }

--- a/src/main/java/edu/example/wayfarer/service/ChatMessageService.java
+++ b/src/main/java/edu/example/wayfarer/service/ChatMessageService.java
@@ -16,4 +16,6 @@ public interface ChatMessageService {
 
     List<ChatMessageResponseDTO> getChatMessageListDTOByRoomId(String roomId);
 
+    boolean isMessageExistsInDB(ChatMessageRequestDTO chatMessageRequestDTO);
+
 }

--- a/src/main/java/edu/example/wayfarer/service/ChatMessageServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/ChatMessageServiceImpl.java
@@ -17,6 +17,7 @@ import edu.example.wayfarer.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -65,6 +66,11 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     @Override
     public List<ChatMessageResponseDTO> getChatMessageListDTOByRoomId(String roomId) {
         return chatMessageRepository.findChatMessageResponseDTOByRoomId(roomId);
+    }
+
+    @Override
+    public List<ChatMessageResponseDTO> getChatMessagesBeforeTimestamp(String roomId, LocalDateTime createdAt) {
+        return chatMessageRepository.findChatMessageResponseDTOByRoomIdBeforeCreatedAt(roomId,createdAt);
     }
 
     private void verifyMemberInRoom(String email, String roomId){

--- a/src/test/java/edu/example/wayfarer/service/ChatMessageTests.java
+++ b/src/test/java/edu/example/wayfarer/service/ChatMessageTests.java
@@ -28,7 +28,8 @@ public class ChatMessageTests {
         ChatMessageRequestDTO chatMessageRequestDTO = new ChatMessageRequestDTO(
             "mP5LcSAt",
                 "aa@aa.com",
-                "이곳에 나홀로"
+                "이곳에 나홀로",
+                "Fri Dec 06 00:12:14 KST 2024"
         );
         chatMessageService.createChatMessage(chatMessageRequestDTO);
     }


### PR DESCRIPTION
- ChatMessage에 대한 Redis 설정 완료 했습니다

- 클라이언트로 부터 받은 채팅을 저장하는 과정입니다. 
1. 클라이언트로 부터 받은 채팅을 레디스에 저장합니다.
2. 12시간 후 레디스에서 db로 저장됩니다. 이때 이미 db에 저장되어있는 데이터는 중복하여 저장하지 않습니다.
3. 레디스에 저장된 데이터는 1일 후 만료되어 삭제됩니다.

- List Message로 채팅메시지를 db에서 읽어 클라이언트에게 보내는 과정입니다
1. 레디스에 저장되어있는 chatMessage를 읽습니다
2. 레디스의 가장 오래된 메시지를 기준으로 그 이전 시간의 message만 db로부터 읽어옵니다
3. 레디스, db에서 읽어온 메시지를 List로 합치고 시간 순으로 정렬합니다.
4. 클라이언트에게 전체 메시지 List를 송신합니다.

클라이언트로 송신받을 때의 시간을 기준으로 시간을 저장해야하기 때문에 DB저장시 createdAt 시간이 자동으로 입력되는 ChatMessage Entity에 있던 @CreationTimestamp 어노테이션은 삭제하였습니다.

**이 때문에 @chadoli27 @Yi-YongMin @ObjectGipi @LimHyeonGyu 팀원분들은 MySQL 워크벤치에서 아래의 쿼리문을 실행하여 변경된 사항을 적용시켜 주시기 바랍니다. merge 후 rds에서는 제가 적용시켜 놓겠습니다.

ALTER TABLE chat_message
MODIFY COLUMN created_at DATETIME;**