### PR TITLE
Fix/#132/웹소켓 채팅 응답에 image nickname 추가

### DIFF
--- a/src/main/java/edu/example/wayfarer/config/RedisConfig.java
+++ b/src/main/java/edu/example/wayfarer/config/RedisConfig.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 
@@ -42,8 +43,14 @@ public class RedisConfig {
     public RedisTemplate<String, Object> jsonRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
+        // 키는 문자열로 처리
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        // 값은 Jackson2JsonRedisSerializer로 JSON 직렬화
+        Jackson2JsonRedisSerializer<Object> jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        template.setValueSerializer(jackson2JsonRedisSerializer);
+        template.setHashValueSerializer(jackson2JsonRedisSerializer);
+
+        template.setHashKeySerializer(new StringRedisSerializer());
         template.afterPropertiesSet();
         return template;
     }

--- a/src/main/java/edu/example/wayfarer/controller/WebSocketController.java
+++ b/src/main/java/edu/example/wayfarer/controller/WebSocketController.java
@@ -4,6 +4,7 @@ import edu.example.wayfarer.exception.WebSocketException;
 import edu.example.wayfarer.exception.WebSocketTaskException;
 import edu.example.wayfarer.handler.ChatHandler;
 import edu.example.wayfarer.handler.MarkerHandler;
+import edu.example.wayfarer.handler.MemberHandler;
 import edu.example.wayfarer.handler.ScheduleHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -25,6 +26,7 @@ public class WebSocketController {
     private final ChatHandler chatHandler;
     private final MarkerHandler markerHandler;
     private final ScheduleHandler scheduleHandler;
+    private final MemberHandler memberHandler;
 
     // WebSocket 연결 이벤트 처리
     @EventListener
@@ -66,6 +68,16 @@ public class WebSocketController {
     ) {
         scheduleHandler.handleSchedule(roomId, schedulePayload);
 
+    }
+
+    // 멤버 관련 처리
+    @MessageMapping("room/{roomId}/member")
+    public void handleMember(
+            @DestinationVariable String roomId,
+            @Payload Map<String, Object> memberPayload,
+            SimpMessageHeaderAccessor headerAccessor
+    ) {
+        memberHandler.handleMember(roomId, memberPayload);
     }
 
     private String getEmail(SimpMessageHeaderAccessor headerAccessor) {

--- a/src/main/java/edu/example/wayfarer/handler/ChatHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/ChatHandler.java
@@ -1,5 +1,8 @@
 package edu.example.wayfarer.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.example.wayfarer.converter.ChatMessageConverter;
 import edu.example.wayfarer.converter.WebSocketMessageConverter;
 import edu.example.wayfarer.dto.chatMessage.ChatMessageRequestDTO;
@@ -27,7 +30,9 @@ import java.util.stream.Collectors;
 public class ChatHandler {
     private final SimpMessagingTemplate template;
     private final ChatMessageService chatMessageService;
+    private final ObjectMapper objectMapper;
     public static final String CHAT_CACHE_PREFIX = "ChatMessage:";
+
 
     @Autowired
     @Qualifier("jsonRedisTemplate")
@@ -58,9 +63,9 @@ public class ChatHandler {
         Map<String, Object> welcomeMessage = new LinkedHashMap<>();
         welcomeMessage.put("action", "WELCOME_MESSAGE");
         welcomeMessage.put("data", Map.of(
-                "sender", "System",
-                "message", email + " 님이 입장하셨습니다.",
-                "timestamp", timestampFormat.format(new Date())
+                        "sender", "System",
+                        "message", email + " 님이 입장하셨습니다.",
+                        "timestamp", timestampFormat.format(new Date())
                 )
         );
 
@@ -70,6 +75,21 @@ public class ChatHandler {
     }
 
     private void broadcastMessage(String roomId, String email, Map<String, Object> data) {
+        String memberJson = (String) jsonRedisTemplate.opsForHash().get("Member:" + roomId, email);
+        String nickname=null;
+        String profileImage=null;
+        if (memberJson != null) {
+            try {
+                // JSON 문자열을 JsonNode로 변환
+                JsonNode jsonNode = objectMapper.readTree(memberJson);
+                // nickname과 profileImage 추출
+                nickname = jsonNode.get("nickname").asText();
+                profileImage = jsonNode.get("profileImage").asText();
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        }
+
         String message = (String) data.get("message");
         if (message == null) {
             throw new WebSocketTaskException(WebSocketException.INVALID_MESSAGE_FORMAT);
@@ -80,7 +100,9 @@ public class ChatHandler {
         broadcastMessage.put("data", Map.of(
                 "sender", email,
                 "message", message,
-                "timestamp", timestampFormat.format(new Date())
+                "timestamp", timestampFormat.format(new Date()),
+                "nickname", nickname,
+                "profileImage", profileImage
                 )
         );
 
@@ -93,84 +115,85 @@ public class ChatHandler {
         template.convertAndSend("/topic/room/" + roomId, broadcastMessage);
     }
 
-    private void listMessages(String roomId) {
 
-        //레디스에서 메시지 읽기
-        List<ChatMessageResponseDTO> redisMessages = readMessagesFromRedis(roomId);
-        log.debug("redisMessages: {}", redisMessages);
-        //레디스에서 읽은 메시지가 있으면 가장 첫 번째 메시지를 기준으로 timestamp 추출
-        LocalDateTime latestRedisTimestamp = null;
-        if (!redisMessages.isEmpty()) {
-            ChatMessageResponseDTO firstRedisMessage = redisMessages.get(0); // 레디스에 저장된 가장 오래된 메시지
-            latestRedisTimestamp = firstRedisMessage.createdAt();
+        private void listMessages(String roomId) {
+
+            //레디스에서 메시지 읽기
+            List<ChatMessageResponseDTO> redisMessages = readMessagesFromRedis(roomId);
+            log.debug("redisMessages: {}", redisMessages);
+            //레디스에서 읽은 메시지가 있으면 가장 첫 번째 메시지를 기준으로 timestamp 추출
+            LocalDateTime latestRedisTimestamp = null;
+            if (!redisMessages.isEmpty()) {
+                ChatMessageResponseDTO firstRedisMessage = redisMessages.get(0); // 레디스에 저장된 가장 오래된 메시지
+                latestRedisTimestamp = firstRedisMessage.createdAt();
+            }
+
+            //DB에서 레디스에 저장된 메시지보다 이전 시간대의 메시지 읽어오기
+            List<ChatMessageResponseDTO> dbMessages = new ArrayList<>();
+            if (latestRedisTimestamp != null) {
+                // 레디스 메시지보다 이전에 생성된 메시지들을 DB에서 읽어옴
+                dbMessages = getChatMessagesBeforeTimestamp(roomId, latestRedisTimestamp);
+            }
+            log.debug("DB Messages: {}", dbMessages);
+
+            //레디스와 DB에서 읽은 메시지를 합치기 (중복 제거)
+            List<ChatMessageResponseDTO> allMessages = mergeMessages(redisMessages, dbMessages);
+
+            //WebSocketMessageConverter로 List message 생성
+            WebSocketMessageConverter<List<ChatMessageResponseDTO>> listConverter = new WebSocketMessageConverter<>();
+            WebSocketMessageConverter.WebsocketMessage<List<ChatMessageResponseDTO>> listMessage =
+                    listConverter.createMessage("LIST_MESSAGES", allMessages);
+            log.debug("LIST MESSAGES: " + listMessage);
+
+            template.convertAndSend("/topic/room/" + roomId, listMessage);
+
+
         }
 
-        //DB에서 레디스에 저장된 메시지보다 이전 시간대의 메시지 읽어오기
-        List<ChatMessageResponseDTO> dbMessages = new ArrayList<>();
-        if (latestRedisTimestamp != null) {
-            // 레디스 메시지보다 이전에 생성된 메시지들을 DB에서 읽어옴
-            dbMessages = getChatMessagesBeforeTimestamp(roomId, latestRedisTimestamp);
-        }
-        log.debug("DB Messages: {}", dbMessages);
+        private List<ChatMessageResponseDTO> readMessagesFromRedis(String roomId) {
+            // Redis에서 메시지 가져오기
+            List <Object> redisMessages = jsonRedisTemplate.opsForList().range(CHAT_CACHE_PREFIX+roomId, 0, -1);
+            // 메시지를 DTO로 변환
+            if (redisMessages == null || redisMessages.isEmpty()) {
+                return new ArrayList<>();
+            }
 
-        //레디스와 DB에서 읽은 메시지를 합치기 (중복 제거)
-        List<ChatMessageResponseDTO> allMessages = mergeMessages(redisMessages, dbMessages);
-
-        //WebSocketMessageConverter로 List message 생성
-        WebSocketMessageConverter<List<ChatMessageResponseDTO>> listConverter = new WebSocketMessageConverter<>();
-        WebSocketMessageConverter.WebsocketMessage<List<ChatMessageResponseDTO>> listMessage =
-                listConverter.createMessage("LIST_MESSAGES", allMessages);
-        log.debug("LIST MESSAGES: " + listMessage);
-
-        template.convertAndSend("/topic/room/" + roomId, listMessage);
-
-
-    }
-
-    private List<ChatMessageResponseDTO> readMessagesFromRedis(String roomId) {
-        // Redis에서 메시지 가져오기
-        List <Object> redisMessages = jsonRedisTemplate.opsForList().range(CHAT_CACHE_PREFIX+roomId, 0, -1);
-        // 메시지를 DTO로 변환
-        if (redisMessages == null || redisMessages.isEmpty()) {
-            return new ArrayList<>();
+            return redisMessages.stream()
+                    .filter(message -> message instanceof Map<?, ?>) // 메시지가 Map 형태인지 확인
+                    .map(message -> {
+                        @SuppressWarnings("unchecked") // 타입 경고 억제
+                        Map<String, Object> messageMap = (Map<String, Object>) message;
+                        return convertToChatMessageResponseDTO(roomId, messageMap);
+                    })
+                    .toList();
         }
 
-        return redisMessages.stream()
-                .filter(message -> message instanceof Map<?, ?>) // 메시지가 Map 형태인지 확인
-                .map(message -> {
-                    @SuppressWarnings("unchecked") // 타입 경고 억제
-                    Map<String, Object> messageMap = (Map<String, Object>) message;
-                    return convertToChatMessageResponseDTO(roomId, messageMap);
-                })
-                .toList();
+        private ChatMessageResponseDTO convertToChatMessageResponseDTO(String roomId, Map<String, Object> messageMap) {
+            // 메시지 맵에서 필요한 데이터 추출
+
+            String email = (String) ((Map<?, ?>) messageMap.get("data")).get("sender");
+            String content = (String) ((Map<?, ?>) messageMap.get("data")).get("message");
+            String stringCreatedAt = (String) ((Map<?, ?>) messageMap.get("data")).get("timestamp");
+            LocalDateTime createdAt = ChatMessageConverter.stringTOLocalDateTime(stringCreatedAt);
+
+            // ChatMessageResponseDTO 객체 생성 및 반환
+            return new ChatMessageResponseDTO(roomId, email, content, createdAt);
+        }
+
+        // DB에서 레디스 메시지 시간대 이전의 메시지 불러오기
+        private List<ChatMessageResponseDTO> getChatMessagesBeforeTimestamp(String roomId, LocalDateTime createdAt) {
+            return chatMessageService.getChatMessagesBeforeTimestamp(roomId, createdAt);
+        }
+
+        private List<ChatMessageResponseDTO> mergeMessages(List<ChatMessageResponseDTO> redisMessages, List<ChatMessageResponseDTO> dbMessages) {
+            // 중복 제거 및 합치기
+            Set<ChatMessageResponseDTO> uniqueMessages = new HashSet<>();
+            uniqueMessages.addAll(redisMessages);
+            uniqueMessages.addAll(dbMessages);
+
+            return uniqueMessages.stream()
+                    .sorted(Comparator.comparing(ChatMessageResponseDTO::createdAt))
+                    .collect(Collectors.toList());
+        }
+
     }
-
-    private ChatMessageResponseDTO convertToChatMessageResponseDTO(String roomId, Map<String, Object> messageMap) {
-        // 메시지 맵에서 필요한 데이터 추출
-
-        String email = (String) ((Map<?, ?>) messageMap.get("data")).get("sender");
-        String content = (String) ((Map<?, ?>) messageMap.get("data")).get("message");
-        String stringCreatedAt = (String) ((Map<?, ?>) messageMap.get("data")).get("timestamp");
-        LocalDateTime createdAt = ChatMessageConverter.stringTOLocalDateTime(stringCreatedAt);
-
-        // ChatMessageResponseDTO 객체 생성 및 반환
-        return new ChatMessageResponseDTO(roomId, email, content, createdAt);
-    }
-
-    // DB에서 레디스 메시지 시간대 이전의 메시지 불러오기
-    private List<ChatMessageResponseDTO> getChatMessagesBeforeTimestamp(String roomId, LocalDateTime createdAt) {
-        return chatMessageService.getChatMessagesBeforeTimestamp(roomId, createdAt);
-    }
-
-    private List<ChatMessageResponseDTO> mergeMessages(List<ChatMessageResponseDTO> redisMessages, List<ChatMessageResponseDTO> dbMessages) {
-        // 중복 제거 및 합치기
-        Set<ChatMessageResponseDTO> uniqueMessages = new HashSet<>();
-        uniqueMessages.addAll(redisMessages);
-        uniqueMessages.addAll(dbMessages);
-
-        return uniqueMessages.stream()
-                .sorted(Comparator.comparing(ChatMessageResponseDTO::createdAt))
-                .collect(Collectors.toList());
-    }
-
-}

--- a/src/main/java/edu/example/wayfarer/handler/MemberHandler.java
+++ b/src/main/java/edu/example/wayfarer/handler/MemberHandler.java
@@ -1,0 +1,74 @@
+package edu.example.wayfarer.handler;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.example.wayfarer.converter.WebSocketMessageConverter;
+import edu.example.wayfarer.dto.marker.MarkerResponseDTO;
+import edu.example.wayfarer.dto.member.MemberResponseDTO;
+import edu.example.wayfarer.exception.WebSocketException;
+import edu.example.wayfarer.exception.WebSocketTaskException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class MemberHandler {
+    @Autowired
+    @Qualifier("jsonRedisTemplate")
+    private RedisTemplate<String, Object> jsonRedisTemplate;
+    private final SimpMessagingTemplate template;
+    private final ObjectMapper objectMapper;
+
+    public void handleMember(String roomId, Map<String, Object> memberPayload) {
+        //클라이언트가 보낸 Payload를 action과 data로 분리
+        String action = (String) memberPayload.get("action");
+        Map<String, Object> data = (Map<String, Object>) memberPayload.get("data");
+
+        log.debug("action: " + action);
+
+        if (action.equals("LIST_MEMBERS")) {
+            // 특정 키에 저장된 모든 필드와 값을 조회
+            Map<Object, Object> roomMembers = jsonRedisTemplate.opsForHash().entries("Member:" + roomId);
+            List<MemberResponseDTO> memberList = new ArrayList<>();
+
+            for (Map.Entry<Object, Object> entry : roomMembers.entrySet()) {
+                String email = (String) entry.getKey();
+                String memberInfo = (String) entry.getValue();
+                try {
+                    // JSON 문자열을 JsonNode로 변환
+                    JsonNode jsonNode = objectMapper.readTree(memberInfo);
+
+                    // 닉네임과 프로필 이미지 가져오기
+                    String nickname = jsonNode.get("nickname").asText();
+                    String profileImage = jsonNode.get("profileImage").asText();
+
+                    MemberResponseDTO memberResponseDTO = new MemberResponseDTO(email, nickname, profileImage);
+                    memberList.add(memberResponseDTO);
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                }
+            }
+            WebSocketMessageConverter<List<MemberResponseDTO>> listConverter = new WebSocketMessageConverter<>();
+            WebSocketMessageConverter.WebsocketMessage<List<MemberResponseDTO>> listMembersMessage =
+                    listConverter.createMessage("LIST_MEMBERS", memberList);
+            log.debug("listMembersMessage: " + listMembersMessage);
+
+            template.convertAndSend("/topic/room/" + roomId + "/member", listMembersMessage);
+        } else {
+            throw new WebSocketTaskException(WebSocketException.INVALID_ACTION);
+        }
+    }
+}

--- a/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
+++ b/src/main/java/edu/example/wayfarer/service/RoomServiceImpl.java
@@ -14,6 +14,9 @@ import edu.example.wayfarer.exception.RoomException;
 import edu.example.wayfarer.repository.*;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +28,9 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class RoomServiceImpl implements RoomService {
+    @Autowired
+    @Qualifier("jsonRedisTemplate")
+    private RedisTemplate<String, Object> jsonRedisTemplate;
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
     private final MemberRoomRepository memberRoomRepository;
@@ -110,6 +116,7 @@ public class RoomServiceImpl implements RoomService {
 
         verifyHost(member.getEmail(), room.getHostEmail());
 
+        jsonRedisTemplate.delete("Member:" + roomId);
         roomRepository.delete(room);
     }
 


### PR DESCRIPTION

**레디스의 키값은 Member:{RoomId} 입니다.** 
이는 해시 구조로 field로 email을, value로 nickname과 profileImage를 담고 있습니다.
Member:{RoomId}의 캐시는 만료되지 않고,  사용자의 입.퇴장, 방 삭제에 따라 같이 생성/삭제 되도록 했습니다. 

- 사용자가 방에 join시 작동하는 MemberRoomService 의 create 메서드에 해당 사용자 정보로 레디스에 캐시 등록하도록 했습니다
- 사용자가 방에서 나갈때의 MemberRooomService의 delete 메서드에 해당 사용자의 정보가 레디스 캐시로부터 삭제되도록 했습니다.
- 방이 삭제되는 RoomService의 delete 메서드에 해당 방을 키로 가지는 레디스 캐시가 삭제되도록 했습니다. 

**WebSocket**
- 웹소켓 채팅 응답으로 profileImage와 nickname을 추가하였습니다.
- 웹소켓에 새로운 구독경로 /topic/room/{roomId}/member를 추가하여 "LIST_MEMBERS" action으로 메시지 송신시, 해당 방에 참가하는 사용자들의 정보를 레디스로 부터 읽어 클라이언트에게 브로드캐스팅합니다.